### PR TITLE
Implement the Standard Gamepad

### DIFF
--- a/deps/openvr/src/ivrsystem.cpp
+++ b/deps/openvr/src/ivrsystem.cpp
@@ -801,6 +801,14 @@ NAN_METHOD(IVRSystem::GetControllerState)
 
           buttons->Set(11, Number::New(Isolate::GetCurrent(), controllerState.rAxis[0].x));
           buttons->Set(12, Number::New(Isolate::GetCurrent(), controllerState.rAxis[0].y));
+          buttons->Set(13, Number::New(Isolate::GetCurrent(), controllerState.rAxis[1].x));
+          buttons->Set(14, Number::New(Isolate::GetCurrent(), controllerState.rAxis[1].y));
+          buttons->Set(15, Number::New(Isolate::GetCurrent(), controllerState.rAxis[2].x));
+          buttons->Set(16, Number::New(Isolate::GetCurrent(), controllerState.rAxis[2].y));
+          buttons->Set(17, Number::New(Isolate::GetCurrent(), controllerState.rAxis[3].x));
+          buttons->Set(18, Number::New(Isolate::GetCurrent(), controllerState.rAxis[3].y));
+          buttons->Set(19, Number::New(Isolate::GetCurrent(), controllerState.rAxis[4].x));
+          buttons->Set(20, Number::New(Isolate::GetCurrent(), controllerState.rAxis[4].y));
 
           break;
         }

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ const localFloat32Array3 = zeroMatrix.toArray(new Float32Array(16));
 const localFloat32Array4 = new Float32Array(16);
 const localFovArray = new Float32Array(4);
 const localFovArray2 = new Float32Array(4);
-const localGamepadArray = new Float32Array(16);
+const localGamepadArray = new Float32Array(24);
 
 const handEntrySize = (1 + (5 * 5)) * (3 + 3);
 const maxNumPlanes = 32 * 3;
@@ -779,14 +779,17 @@ const _bindWindow = (window, newWindowCb) => {
         leftGamepad.buttons[1].pressed = localGamepadArray[5] !== 0; // trigger
         leftGamepad.buttons[2].pressed = localGamepadArray[3] !== 0; // grip
         leftGamepad.buttons[3].pressed = localGamepadArray[2] !== 0; // menu
+        leftGamepad.buttons[4].pressed = localGamepadArray[1] !== 0; // system
 
         leftGamepad.buttons[0].touched = localGamepadArray[9] !== 0; // pad
         leftGamepad.buttons[1].touched = localGamepadArray[10] !== 0; // trigger
         leftGamepad.buttons[2].touched = localGamepadArray[8] !== 0; // grip
         leftGamepad.buttons[3].touched = localGamepadArray[7] !== 0; // menu
+        leftGamepad.buttons[4].touched = localGamepadArray[6] !== 0; // system
 
-        leftGamepad.axes[0] = localGamepadArray[11];
-        leftGamepad.axes[1] = localGamepadArray[12];
+        for (let i = 0; i < 10; i++)
+          leftGamepad.axes[i] = localGamepadArray[11+i];
+        leftGamepad.buttons[1].value = leftGamepad.axes[2]; // trigger
 
         gamepads[0] = leftGamepad;
       } else {
@@ -805,14 +808,17 @@ const _bindWindow = (window, newWindowCb) => {
         rightGamepad.buttons[1].pressed = localGamepadArray[5] !== 0; // trigger
         rightGamepad.buttons[2].pressed = localGamepadArray[3] !== 0; // grip
         rightGamepad.buttons[3].pressed = localGamepadArray[2] !== 0; // menu
+        rightGamepad.buttons[4].pressed = localGamepadArray[1] !== 0; // system
 
         rightGamepad.buttons[0].touched = localGamepadArray[9] !== 0; // pad
         rightGamepad.buttons[1].touched = localGamepadArray[10] !== 0; // trigger
         rightGamepad.buttons[2].touched = localGamepadArray[8] !== 0; // grip
         rightGamepad.buttons[3].touched = localGamepadArray[7] !== 0; // menu
+        rightGamepad.buttons[4].touched = localGamepadArray[6] !== 0; // system
 
-        rightGamepad.axes[0] = localGamepadArray[11];
-        rightGamepad.axes[1] = localGamepadArray[12];
+        for (let i = 0; i < 10; i++)
+          rightGamepad.axes[i] = localGamepadArray[11+i];
+        rightGamepad.buttons[1].value = rightGamepad.axes[2]; // trigger
 
         gamepads[1] = rightGamepad;
       } else {
@@ -933,6 +939,7 @@ const _bindWindow = (window, newWindowCb) => {
 
     // update media frames
     nativeVideo.Video.updateAll();
+    nativeVideo.VideoCapture.updateAll();
     if (args.performance) {
       const now = Date.now();
       const diff = now - timestamps.last;

--- a/index.js
+++ b/index.js
@@ -939,7 +939,6 @@ const _bindWindow = (window, newWindowCb) => {
 
     // update media frames
     nativeVideo.Video.updateAll();
-    nativeVideo.VideoCapture.updateAll();
     if (args.performance) {
       const now = Date.now();
       const diff = now - timestamps.last;


### PR DESCRIPTION
See https://w3c.github.io/gamepad/#remapping

This PR adds support for 16 buttons and 10 axes

(Additionally, vive controllers now properly expose their trigger axis value.)

Before merging this PR, you'll need to modify vr-display/index.js with the additional buttons and axes:


```
class Gamepad {
  constructor(hand, index) {
    this.hand = hand;
    this.index = index;

    this.connected = true;
    this.buttons = [];
    for (let i = 0; i < 16; i++)
      this.buttons.push(new GamepadButton());
    this.pose = new GamepadPose();
    this.axes = new Float32Array(10);
    this.hapticActuators = [new GamepadHapticActuator(this)];

    this.ontriggerhapticpulse = null;

    Gamepad.nonstandard.init.call(this);
  }

  copy(gamepad) {
    this.connected = gamepad.connected;
    for (let i = 0; i < this.buttons.length; i++) {
      this.buttons[i].copy(gamepad.buttons[i]);
    }
    this.pose.copy(gamepad.pose);
    this.axes.set(gamepad.axes);

    Gamepad.nonstandard.copy.call(this, gamepad);
  }
}
```

Ditto for vr-display/vr-display.js:

```
class Gamepad {
  constructor(hand, index) {
    this.hand = hand;
    this.index = index;

    this.connected = true;
    this.buttons = [];
    for (let i = 0; i < 16; i++)
      this.buttons.push(new GamepadButton());
    this.pose = new GamepadPose();
    this.axes = new Float32Array(10);

    Gamepad.nonstandard.init.call(this);
  }

  copy(gamepad) {
    this.connected = gamepad.connected;
    for (let i = 0; i < this.buttons.length; i++) {
      this.buttons[i].copy(gamepad.buttons[i]);
    }
    this.pose.copy(gamepad.pose);
    this.axes.set(gamepad.axes);

    Gamepad.nonstandard.copy.call(this, gamepad);
  }
}
```