### PR TITLE
Webcam threading support

### DIFF
--- a/deps/exokit-bindings/videocontext/include/Video.h
+++ b/deps/exokit-bindings/videocontext/include/Video.h
@@ -130,7 +130,7 @@ class VideoDevice : public ObjectWrap {
 };
 
 extern std::vector<Video *> videos;
-extern std::vector<VideoDevice *> cameras;
+extern std::vector<VideoDevice *> videoDevices;
 
 }
 

--- a/deps/exokit-bindings/videocontext/include/Video.h
+++ b/deps/exokit-bindings/videocontext/include/Video.h
@@ -107,26 +107,22 @@ class VideoCamera;
 class VideoDevice : public ObjectWrap {
   public:
     static Handle<Object> Initialize(Isolate *isolate);
-    bool Update();
 
   protected:
     static NAN_METHOD(New);
     static NAN_METHOD(Open);
     static NAN_METHOD(Close);
-    static NAN_METHOD(Update);
     static NAN_GETTER(WidthGetter);
     static NAN_GETTER(HeightGetter);
     static NAN_GETTER(SizeGetter);
     static NAN_GETTER(DataGetter);
-    static NAN_METHOD(UpdateAll);
 
     VideoDevice();
     ~VideoDevice();
 
   private:
-    VideoCamera* dev;
+    VideoCamera *dev;
     Nan::Persistent<Uint8ClampedArray> dataArray;
-    bool dataDirty;
 };
 
 extern std::vector<Video *> videos;

--- a/deps/exokit-bindings/videocontext/include/VideoMode.h
+++ b/deps/exokit-bindings/videocontext/include/VideoMode.h
@@ -3,8 +3,10 @@
 
 #include "VideoCommon.h"
 
-#include <cassert>
-
+// #include <cassert>
+// #include <iomanip> // setprecision
+#include <mutex>
+#include <thread>
 
 extern "C" {
 #include <libavutil/avstring.h>
@@ -18,22 +20,24 @@ namespace ffmpeg {
 class VideoCamera
 {
 public:
-  AVFormatContext* pFormatCtx;
+  AVFormatContext *pFormatCtx;
+  AVFrame *pFrameRGB;
   int videoStream;
-  AVCodec* pCodec;
-  AVFrame* pFrame;
-  AVFrame* pFrameRGB;
-  AVPacket packet;
-  VideoCamera(AVFormatContext* formatContext, AVCodec* codec, int videoStream);
+  bool *pLive;
+  std::mutex *pMutex;
+  bool *pFrameReady;
+
+  VideoCamera(AVFormatContext *formatContext, int videoStream);
   ~VideoCamera();
-  AVCodecContext* getCodecContext() const;
+
+  AVCodecContext *getCodecContext() const;
   AVPixelFormat getFormat() const;
   size_t getWidth() const;
   size_t getHeight() const;
   size_t getSize() const;
-  void copy(uint8_t* buffer) const;
-  bool update();
-  static VideoCamera* open(const char* deviceName, AVDictionary* options);
+  bool isFrameReady() const;
+  void pullUpdate(uint8_t *buffer) const;
+  static VideoCamera* open(const char *deviceName, AVDictionary *options);
 };
 
 struct VideoMode {

--- a/deps/exokit-bindings/videocontext/src/Video.cpp
+++ b/deps/exokit-bindings/videocontext/src/Video.cpp
@@ -552,14 +552,14 @@ FrameStatus Video::advanceToFrameAt(double timestamp) {
 
 
 VideoDevice::VideoDevice() : dataDirty(true), dev(nullptr) {
-  cameras.push_back(this);
+  videoDevices.push_back(this);
 }
 
 VideoDevice::~VideoDevice() {
   if (dev) {
     VideoMode::close(dev);
   }
-  cameras.erase(std::find(cameras.begin(), cameras.end(), this));
+  videoDevices.erase(std::find(videoDevices.begin(), videoDevices.end(), this));
 }
 
 Handle<Object> VideoDevice::Initialize(Isolate *isolate) {
@@ -706,13 +706,12 @@ NAN_GETTER(VideoDevice::DataGetter) {
 }
 
 NAN_METHOD(VideoDevice::UpdateAll) {
-  for (auto i : cameras) {
+  for (auto i : videoDevices) {
     i->Update();
   }
 }
 
-
 std::vector<Video *> videos;
-std::vector<VideoDevice *> cameras;
+std::vector<VideoDevice *> videoDevices;
 
 }

--- a/deps/exokit-bindings/videocontext/src/VideoMode.cpp
+++ b/deps/exokit-bindings/videocontext/src/VideoMode.cpp
@@ -1,8 +1,5 @@
 #include <VideoMode.h>
 
-#include <cassert>
-#include <iomanip> // setprecision
-
 extern "C" {
 #include <libavutil/avstring.h>
 #include <libavcodec/avcodec.h>
@@ -19,7 +16,6 @@ VideoCamera::VideoCamera(AVFormatContext* formatContext, AVCodec* codec, int vid
 , pFrame(av_frame_alloc())
 , pFrameRGB(av_frame_alloc())
 {
-  assert(videoStream >= 0);
 }
 
 VideoCamera::~VideoCamera()
@@ -39,7 +35,6 @@ VideoCamera::~VideoCamera()
 AVCodecContext*
 VideoCamera::getCodecContext() const
 {
-  assert(videoStream >= 0 && pFormatCtx);
   return pFormatCtx->streams[videoStream]->codec;
 }
 

--- a/deps/exokit-bindings/videocontext/src/VideoMode.cpp
+++ b/deps/exokit-bindings/videocontext/src/VideoMode.cpp
@@ -173,17 +173,17 @@ VideoCamera::open(const char* deviceName, AVDictionary* options)
 
 template<typename Out>
 static void split(const std::string &s, char delim, Out result) {
-    std::stringstream ss(s);
-    std::string item;
-    while (std::getline(ss, item, delim)) {
-        *(result++) = item;
-    }
+  std::stringstream ss(s);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    *(result++) = item;
+  }
 }
 
 static std::vector<std::string> split(const std::string &s, char delim) {
-    std::vector<std::string> elems;
-    split(s, delim, std::back_inserter(elems));
-    return elems;
+  std::vector<std::string> elems;
+  split(s, delim, std::back_inserter(elems));
+  return elems;
 }
 
 VideoCamera*

--- a/deps/exokit-bindings/videocontext/src/VideoMode.cpp
+++ b/deps/exokit-bindings/videocontext/src/VideoMode.cpp
@@ -16,6 +16,22 @@ VideoCamera::VideoCamera(AVFormatContext* formatContext, AVCodec* codec, int vid
 , pFrame(av_frame_alloc())
 , pFrameRGB(av_frame_alloc())
 {
+AVPixelFormat normalizeFormat(AVPixelFormat pixFormat) {
+  switch (pixFormat) {
+    case AV_PIX_FMT_YUVJ420P :
+      pixFormat = AV_PIX_FMT_YUV420P;
+      break;
+    case AV_PIX_FMT_YUVJ422P  :
+      pixFormat = AV_PIX_FMT_YUV422P;
+      break;
+    case AV_PIX_FMT_YUVJ444P   :
+      pixFormat = AV_PIX_FMT_YUV444P;
+      break;
+    case AV_PIX_FMT_YUVJ440P :
+      pixFormat = AV_PIX_FMT_YUV440P;
+      break;
+  }
+  return pixFormat;
 }
 
 VideoCamera::~VideoCamera()
@@ -42,22 +58,7 @@ AVPixelFormat
 VideoCamera::getFormat() const
 {
   // https://stackoverflow.com/a/23216860
-  AVPixelFormat pixFormat = getCodecContext()->pix_fmt;
-  switch (pixFormat) {
-    case AV_PIX_FMT_YUVJ420P :
-      pixFormat = AV_PIX_FMT_YUV420P;
-      break;
-    case AV_PIX_FMT_YUVJ422P  :
-      pixFormat = AV_PIX_FMT_YUV422P;
-      break;
-    case AV_PIX_FMT_YUVJ444P   :
-      pixFormat = AV_PIX_FMT_YUV444P;
-      break;
-    case AV_PIX_FMT_YUVJ440P :
-      pixFormat = AV_PIX_FMT_YUV440P;
-      break;
-  }
-  return pixFormat;
+  return normalizeFormat(getCodecContext()->pix_fmt);
 }
 
 size_t

--- a/index.js
+++ b/index.js
@@ -905,7 +905,6 @@ const _bindWindow = (window, newWindowCb) => {
 
     // update media frames
     nativeVideo.Video.updateAll();
-    nativeVideo.VideoDevice.updateAll();
     if (args.performance) {
       const now = Date.now();
       const diff = now - timestamps.last;


### PR DESCRIPTION
A major bug was introduced in https://github.com/webmixedreality/exokit/pull/86/files, https://github.com/webmixedreality/exokit/pull/87/files.

Turns out that ffmpeg webcam streaming blocks on reading frames. Since we were doing that in the mainloop, that capped the main render loop to the webcam rate (e.g. 30 FPS or lower). For AR/VR/Magic Leap this is a major UX breakage.

The fix here does the webcam processing asynchronously in a thread; the rest of the logic remains the same.