### PR TITLE
Fix build error

### DIFF
--- a/deps/exokit-bindings/videocontext/src/VideoMode.cpp
+++ b/deps/exokit-bindings/videocontext/src/VideoMode.cpp
@@ -1,6 +1,9 @@
 #include <VideoMode.h>
 #include <VideoCamera.h>
 
+#include <algorithm>
+#include <iterator>
+
 namespace ffmpeg {
 
 template<typename Out>


### PR DESCRIPTION
For some reason, our appveyor build process was failing with an error about `std::back_inserter` being undefined. This appears to fix it.

Not sure why you're not running into the same problem.