### PR TITLE
Separate device/window render

### DIFF
--- a/core.js
+++ b/core.js
@@ -3409,11 +3409,11 @@ const tickAnimationFrame = () => {
   }
 };
 
-const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
+const _makeRequestAnimationFrame = (window, prio = 0) => (fn, priority = prio) => {
   fn[windowSymbol] = window;
   fn[prioritySymbol] = priority;
   rafCbs.push(fn);
-  rafCbs.sort((a, b) => b[prioritySymbol] - a[prioritySymbol]);
+  rafCbs.sort((a, b) => a[prioritySymbol] - b[prioritySymbol]);
   return fn;
 };
 const _getFakeVrDisplay = window => window[mrDisplaysSymbol].fakeVrDisplay;
@@ -3913,7 +3913,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       }
     }
   };
-  window.requestAnimationFrame = _makeRequestAnimationFrame(window);
+  window.requestAnimationFrame = _makeRequestAnimationFrame(window, 2);
   window.cancelAnimationFrame = fn => {
     const index = rafCbs.indexOf(fn);
     if (index !== -1) {


### PR DESCRIPTION
This PR lets sites render something to the window and something
different to the HMD.

You can test using the following sites. (Press P to load into VR.)

A standard VR site: http://emkolar.ninja

A site that renders differently in the HMD than the window: https://files.webmr.io/_files/shawnpresser@gmail.com/sloth-necessary-29/leetsaber/index.html

NOTE: if a user site uses window.RAF instead of device.RAF while VR is enabled, the HMD will be one frame behind, which is pretty jarring. You can see this for yourself in the first site.

I'm not sure how to do better than this. Thoughts?