### PR TITLE
<img src> threading

### DIFF
--- a/core.js
+++ b/core.js
@@ -4884,13 +4884,15 @@ exokit.setNativeBindingsModule = nativeBindingsModule => {
                 return Promise.reject(new Error(`img src got invalid status code (url: ${JSON.stringify(src)}, code: ${res.status})`));
               }
             })
-            .then(arrayBuffer => {
-              try {
-                this.image.load(arrayBuffer);
-              } catch(err) {
-                throw new Error(`failed to decode image: ${err.message} (url: ${JSON.stringify(src)}, size: ${arrayBuffer.byteLength})`);
-              }
-            })
+            .then(arrayBuffer => new Promise((accept, reject) => {
+              this.image.load(arrayBuffer, err => {
+                if (!err) {
+                  accept();
+                } else {
+                  reject(new Error(`failed to decode image: ${err.message} (url: ${JSON.stringify(src)}, size: ${arrayBuffer.byteLength}, message: ${err})`));
+                }
+              });
+            }))
             .then(() => {
               this.dispatchEvent(new Event('load', {target: this}));
             })

--- a/deps/exokit-bindings/canvascontext/include/image-context.h
+++ b/deps/exokit-bindings/canvascontext/include/image-context.h
@@ -13,6 +13,7 @@
 #include <nanosvg.h>
 #include <nanosvgrast.h>
 #include <string>
+#include <thread>
 
 using namespace v8;
 using namespace node;
@@ -24,7 +25,8 @@ public:
   unsigned int GetHeight();
   unsigned int GetNumChannels();
   // unsigned char *GetData();
-  bool Load(const unsigned char *buffer, size_t size, std::string *error = nullptr);
+  static void RunInMainThread(uv_async_t *handle);
+  void Load(Local<ArrayBuffer> arrayBuffer, size_t byteOffset, size_t byteLength, Local<Function> cbFn);
   // void Set(canvas::Image *image);
 
 protected:
@@ -40,6 +42,10 @@ protected:
 private:
   sk_sp<SkImage> image;
   Nan::Persistent<Uint8ClampedArray> dataArray;
+
+  Nan::Persistent<ArrayBuffer> arrayBuffer;
+  Nan::Persistent<Function> cbFn;
+  std::string error;
 
   friend class CanvasRenderingContext2D;
   friend class ImageData;

--- a/deps/exokit-bindings/canvascontext/include/image-context.h
+++ b/deps/exokit-bindings/canvascontext/include/image-context.h
@@ -46,6 +46,7 @@ private:
   Nan::Persistent<ArrayBuffer> arrayBuffer;
   Nan::Persistent<Function> cbFn;
   std::string error;
+  uv_async_t threadAsync;
 
   friend class CanvasRenderingContext2D;
   friend class ImageData;

--- a/deps/exokit-bindings/canvascontext/src/image-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/image-context.cc
@@ -72,7 +72,7 @@ void Image::RunInMainThread(uv_async_t *handle) {
 }
 
 void Image::Load(Local<ArrayBuffer> arrayBuffer, size_t byteOffset, size_t byteLength, Local<Function> cbFn) {
-  if (!this->cbFn.IsEmpty()) {
+  if (this->cbFn.IsEmpty()) {
     unsigned char *buffer = (unsigned char *)arrayBuffer->GetContents().Data() + byteOffset;
 
     this->arrayBuffer.Reset(arrayBuffer);


### PR DESCRIPTION
This moves `Image::Load` to a separate thread for all image types, including SVG. The results are passed back to the main thread via `uv_async_t`.

Performance of loading things (especially models) should be increased, and there should be no visible side effect to user code.