### PR TITLE
Linux WebXR: do not include libexpat

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "native-audio-deps": "0.0.32",
-    "native-canvas-deps": "0.0.22",
+    "native-canvas-deps": "0.0.23",
     "native-graphics-deps": "0.0.16",
     "native-openvr-deps": "0.0.16",
     "native-video-deps": "0.0.23",


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/147.

The bug addressed here is that the Linux Skia build included a copy of libexpat, which was not the same version as the libexpat in various graphics drivers, causing xml parsing crashes without an `LD_PRELOAD`.

I think this is the last of the changes needed for Exokit to work on Arch Linux, provided the deps are installed.