### PR TITLE
Add --xr flag

### DIFF
--- a/core.js
+++ b/core.js
@@ -1100,16 +1100,14 @@ global._makeWindow = (options = {}, parent = null, top = null) => {
       result.sort((a, b) => +b.isPresenting - +a.isPresenting);
       return result;
     },
-    getVRDisplays() {
-      return Promise.resolve(this.getVRDisplaysSync());
-    },
+    getVRDisplays: args.xr === 'webvr' ? () => Promise.resolve(this.getVRDisplaysSync()) : null,
     createVRDisplay() {
       const {fakeVrDisplay} = window[symbols.mrDisplaysSymbol];
       fakeVrDisplay.isActive = true;
       return fakeVrDisplay;
     },
     getGamepads,
-    xr: new XR.XR(window),
+    xr: args.xr === 'webxr' ? new XR.XR(window) : null,
     /* getVRMode: () => vrMode,
     setVRMode: newVrMode => {
       for (let i = 0; i < vrDisplays.length; i++) {

--- a/core.js
+++ b/core.js
@@ -1100,14 +1100,16 @@ global._makeWindow = (options = {}, parent = null, top = null) => {
       result.sort((a, b) => +b.isPresenting - +a.isPresenting);
       return result;
     },
-    getVRDisplays: args.xr === 'webvr' ? () => Promise.resolve(this.getVRDisplaysSync()) : null,
+    getVRDisplays: ['all', 'webvr'].includes(args.xr) ? function() {
+      return Promise.resolve(this.getVRDisplaysSync());
+    } : null,
     createVRDisplay() {
       const {fakeVrDisplay} = window[symbols.mrDisplaysSymbol];
       fakeVrDisplay.isActive = true;
       return fakeVrDisplay;
     },
     getGamepads,
-    xr: args.xr === 'webxr' ? new XR.XR(window) : null,
+    xr: ['all', 'webxr'].includes(args.xr) ? new XR.XR(window) : null,
     /* getVRMode: () => vrMode,
     setVRMode: newVrMode => {
       for (let i = 0; i < vrDisplays.length; i++) {

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ const args = (() => {
       url: minimistArgs._[0] || '',
       home: minimistArgs.home || !!minimistArgs.tab,
       tab: minimistArgs.tab,
-      xr: minimistArgs.xr || 'webxr',
+      xr: minimistArgs.xr || 'all',
       performance: !!minimistArgs.performance,
       size: minimistArgs.size,
       frame: minimistArgs.frame,

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ const args = (() => {
       ],
       string: [
         'tab',
+        'xr',
         'size',
         'image',
       ],
@@ -65,6 +66,7 @@ const args = (() => {
         v: 'version',
         h: 'home',
         t: 'tab',
+        x: 'xr',
         p: 'performance',
         perf: 'performance',
         s: 'size',
@@ -81,6 +83,7 @@ const args = (() => {
       url: minimistArgs._[0] || '',
       home: minimistArgs.home || !!minimistArgs.tab,
       tab: minimistArgs.tab,
+      xr: minimistArgs.xr || 'webxr',
       performance: !!minimistArgs.performance,
       size: minimistArgs.size,
       frame: minimistArgs.frame,


### PR DESCRIPTION
Some sites have buggy WebXR and might be picky about WebVR/WebXR/neither.

For the sake of testing this allows us to flip the mode(s) we support with the `--xr` flag.

`all`, `webxr`, `webvr`, `none` are supported. Default is `all`, which is existing behavior.