### PR TITLE
Remove options arg from _parseDocument*

### DIFF
--- a/core.js
+++ b/core.js
@@ -1456,7 +1456,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         // preserveComments: true,
       });
       const htmlAst = _recurse(xmlAst);
-      return _parseDocumentAst(htmlAst, window[symbols.optionsSymbol], window, false);
+      return _parseDocumentAst(htmlAst, window, false);
     }
   };
   // window.Buffer = Buffer; // XXX non-standard
@@ -1781,7 +1781,7 @@ GlobalContext._makeWindow = _makeWindow;
 
 const _makeWindowWithDocument = (s, options, parent, top) => {
   const window = _makeWindow(options, parent, top);
-  window.document = _parseDocument(s, options, window);
+  window.document = _parseDocument(s, window);
   return window;
 };
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1755,7 +1755,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                 baseUrl: url,
                 dataPath: options.dataPath,
               }, parentWindow, parentWindow.top);
-              const contentDocument = GlobalContext._parseDocument(htmlString, contentWindow[symbols.optionsSymbol], contentWindow);
+              const contentDocument = GlobalContext._parseDocument(htmlString, contentWindow);
               contentDocument.hidden = this.hidden;
 
               contentWindow.document = contentDocument;

--- a/src/Document.js
+++ b/src/Document.js
@@ -6,17 +6,17 @@ const GlobalContext = require('./GlobalContext');
 const symbols = require('./symbols');
 const utils = require('./utils');
 
-const _parseDocument = (s, options, window) => {
+const _parseDocument = (s, window) => {
   const ast = parse5.parse(s, {
     sourceCodeLocationInfo: true,
   });
   ast.tagName = 'document';
-  return _parseDocumentAst(ast, options, window, true);
+  return _parseDocumentAst(ast, window, true);
 };
 module.exports._parseDocument = _parseDocument;
 GlobalContext._parseDocument = _parseDocument;
 
-const _parseDocumentAst = (ast, options, window, uppercase) => {
+const _parseDocumentAst = (ast, window, uppercase) => {
   const document = GlobalContext._fromAST(ast, window, null, null, uppercase);
   return initDocument(document, window);
 };
@@ -175,7 +175,7 @@ class DOMImplementation {
   }
 
   createHTMLDocument() {
-    return _parseDocument('', this._window[symbols.optionsSymbol], this._window);
+    return _parseDocument('', this._window);
   }
 
   hasFeature() {


### PR DESCRIPTION
I think it was pointless, since it wasn't used. And even if it were useful it should always be on the `window` that is also an argument.