### PR TITLE
.appendChild(DocumentFragment) and cloneNode fixes, Range.createContextualFragment

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -49,6 +49,11 @@ function initDocument (document, window) {
     documentFragment.ownerDocument = document;
     return documentFragment;
   };
+  document.createRange = () => {
+    const range = new Range();
+    range.ownerDocument = document;
+    return range;
+  };
   document.createTextNode = text => new DOM.Text(text);
   document.createComment = comment => new DOM.Comment(comment);
   document.createEvent = type => {
@@ -236,9 +241,8 @@ class Document extends DOM.HTMLLoadableElement {
   }
 }
 module.exports.Document = Document;
-
-// FIXME: Temporary until we can refactor out into modules more and not have circular dependencies.
-require('./GlobalContext').Document = Document;
+// FIXME: Temporary until refactor out into modules more and not have circular dependencies.
+GlobalContext.Document = Document;
 
 class DocumentFragment extends DOM.HTMLElement {
   constructor() {
@@ -250,3 +254,16 @@ class DocumentFragment extends DOM.HTMLElement {
   }
 }
 module.exports.DocumentFragment = DocumentFragment;
+
+class Range extends DocumentFragment {
+  constructor() {
+    super('RANGE');
+  }
+
+  createContextualFragment(str) {
+    var fragment = this.ownerDocument.createDocumentFragment();
+    fragment.innerHTML = str;
+    return fragment;
+  }
+}
+module.exports.Range = Range;


### PR DESCRIPTION
- When appending document fragment, append its children. Else it was trying to append a node called `<documentfragment>`.
- Created an empty array to reuse so doesn't have to be recreated each time. Was trying to figure out how to do an IIFE ES6 class method.
- Fixed cloneNode not copying over tagName and ownerDocument.
- Started initial stub with createRange, might add a bit to it, but all I need is the createContextualNode.

Question...normal browsers don't allow DocumentFragment.innerHTML set, I wonder why.

My test case was this A-Frame site:

```html
<script src="https://aframe.io/releases/0.8.2/aframe.min.js"></script>

<script>
  AFRAME.registerComponent('fragment', {
    init: function () {
      var fragment = document.createDocumentFragment();
      var entity = document.createElement('a-entity');
      fragment.appendChild(entity);
      this.el.appendChild(fragment);
    }
  });
</script>

<a-scene fragment>
  <a-box position="0 1.6 -5"></a-box>
</a-scene>
```