### PR TITLE
only add getVRDisplays/xr to navigator if enabled

### DIFF
--- a/core.js
+++ b/core.js
@@ -1061,16 +1061,12 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       result.sort((a, b) => +b.isPresenting - +a.isPresenting);
       return result;
     },
-    getVRDisplays: ['all', 'webvr'].includes(args.xr) ? function() {
-      return Promise.resolve(this.getVRDisplaysSync());
-    } : null,
     createVRDisplay() {
       const {fakeVrDisplay} = window[symbols.mrDisplaysSymbol];
       fakeVrDisplay.isActive = true;
       return fakeVrDisplay;
     },
     getGamepads,
-    xr: ['all', 'webxr'].includes(args.xr) ? new XR.XR(window) : null,
     /* getVRMode: () => vrMode,
     setVRMode: newVrMode => {
       for (let i = 0; i < vrDisplays.length; i++) {
@@ -1095,6 +1091,19 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       vrTextures = newVrTextures;
     }, */
   };
+
+  // WebVR enabled.
+  if (['all', 'webvr'].includes(args.xr)) {
+    window.navigator.getVRDisplays = function() {
+      return Promise.resolve(this.getVRDisplaysSync());
+    }
+  }
+
+  // WebXR enabled.
+  if (['all', 'webxr'].includes(args.xr)) {
+    window.navigator.xr = new XR.XR(window);
+  }
+
   window.destroy = function() {
     this._emit('destroy', {window: this});
   };


### PR DESCRIPTION
three.js r93+ will check `xr in navigator` before switching over to use the WebXR manager. So the latest version of A-Frame doesn't work with Exokit because three.js WebXR doesn't work with A-Frame.

- Only add vr/xr API to navigator if enabled versus nulling it.