### PR TITLE
Bugsnag only in app mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,18 +12,6 @@ const url = require('url');
 const child_process = require('child_process');
 const repl = require('repl');
 
-require(path.join(__dirname, 'bugsnag'));
-require('fault-zone').registerHandler((stack, stackLen) => {
-  const message = new Buffer(stack, 0, stackLen).toString('utf8');
-  console.warn(message);
-  child_process.execFileSync(process.argv[0], [
-    path.join(__dirname, 'bugsnag.js'),
-  ], {
-    input: message,
-  });
-  process.exit(1);
-});
-
 const core = require('./core.js');
 const mkdirp = require('mkdirp');
 const replHistory = require('repl.history');
@@ -1393,6 +1381,18 @@ const _start = () => {
 };
 
 if (require.main === module) {
+  require(path.join(__dirname, 'bugsnag'));
+  require('fault-zone').registerHandler((stack, stackLen) => {
+    const message = new Buffer(stack, 0, stackLen).toString('utf8');
+    console.warn(message);
+    child_process.execFileSync(process.argv[0], [
+      path.join(__dirname, 'bugsnag.js'),
+    ], {
+      input: message,
+    });
+    process.exit(1);
+  });
+
   const _logStack = err => {
     console.warn(err);
   };


### PR DESCRIPTION
`Bugsnag`+`fault-zone` hangs `mocha` tests by holding the loop. So, only add them if this is a module boot rather than a `require`.

Also, not sure if we want to be snagging test results.