### PR TITLE
Catch and log EventTarget dispatchEvent errors

### DIFF
--- a/src/Event.js
+++ b/src/Event.js
@@ -27,7 +27,13 @@ class EventTarget extends EventEmitter {
 
     const _emit = (node, event) => {
       event.currentTarget = this;
-      node._emit(event.type, event);
+
+      try {
+        node._emit(event.type, event);
+      } catch (err) {
+        console.warn(err);
+      }
+
       event.currentTarget = null;
     };
     const _recurse = (node, event) => {


### PR DESCRIPTION
`A-Painter` loaded into Exokit sometimes errors on `vrdisplayactivate`. We are pretty aggressive about emitting it once the document is ready state but A-Frame seems not ready for the event.

Because we don't catch `EventTarget::dispatchEvent` throws, this brings down the site. But I think the correct thing to do here is just to log the error if a site can't handle an emit, especially an internal one.

- Trap and log throws from `dispatchEvent` callbacks.

```
THREE.WebGLRenderer 89
A-PAINTER Version: 1.2
core:a-assets:warn Cross-origin element (e.g., <img>) was requested without `crossorigin` set. A-Frame will re-request the asset with `crossorigin` attribute set. Please set `crossorigin` on the element (e.g., <img crossorigin="anonymous">)  https://cdn.aframe.io/a-painter/sounds/ui_click0.ogg
core:a-assets:warn Cross-origin element (e.g., <img>) was requested without `crossorigin` set. A-Frame will re-request the asset with `crossorigin` attribute set. Please set `crossorigin` on the element (e.g., <img crossorigin="anonymous">)  https://cdn.aframe.io/a-painter/sounds/ui_click1.ogg
core:a-assets:warn Cross-origin element (e.g., <img>) was requested without `crossorigin` set. A-Frame will re-request the asset with `crossorigin` attribute set. Please set `crossorigin` on the element (e.g., <img crossorigin="anonymous">)  https://cdn.aframe.io/a-painter/sounds/ui_menu.ogg
core:a-assets:warn Cross-origin element (e.g., <img>) was requested without `crossorigin` set. A-Frame will re-request the asset with `crossorigin` attribute set. Please set `crossorigin` on the element (e.g., <img crossorigin="anonymous">)  https://cdn.aframe.io/a-painter/sounds/ui_undo.ogg
core:a-assets:warn Cross-origin element (e.g., <img>) was requested without `crossorigin` set. A-Frame will re-request the asset with `crossorigin` attribute set. Please set `crossorigin` on the element (e.g., <img crossorigin="anonymous">)  https://cdn.aframe.io/a-painter/sounds/ui_tick.ogg
core:a-assets:warn Cross-origin element (e.g., <img>) was requested without `crossorigin` set. A-Frame will re-request the asset with `crossorigin` attribute set. Please set `crossorigin` on the element (e.g., <img crossorigin="anonymous">)  https://cdn.aframe.io/a-painter/sounds/ui_paint.ogg
TypeError: Cannot read property 'el' of undefined
    at HTMLElement.value (vendor/aframe-master.js:76047:47)
    at enterVRBound (vendor/aframe-master.js:75921:48)
    at emit (events.js:182:13)
    at EventEmitter.emit (domain.js:442:20)
    at _emit (C:\Users\avaer\Documents\GitHub\exokit\src\Event.js:53:40)
    at window._emit (C:\Users\avaer\Documents\GitHub\exokit\core.js:1565:28)
    at _emit (C:\Users\avaer\Documents\GitHub\exokit\src\Event.js:32:14)
    at _recurse (C:\Users\avaer\Documents\GitHub\exokit\src\Event.js:39:7)
    at dispatchEvent (C:\Users\avaer\Documents\GitHub\exokit\src\Event.js:49:5)
    at Timeout._recurse [as _onTimeout] (C:\Users\avaer\Documents\GitHub\exokit\index.js:1129:18)
core:schema:warn Unknown property `button` for component/system `teleport-controls`.
core:schema:warn Unknown property `ground` for component/system `teleport-controls`.
core:schema:warn Unknown property `button` for component/system `teleport-controls`.
core:schema:warn Unknown property `ground` for component/system `teleport-controls`.
THREE.WebGLRenderer: image is not power of two (3584x2944). Resized to 2048x2048 <img src="assets/images/brush_atlas.png"/>
OBJLoader: 2.854ms
OBJLoader: 1.342ms
OBJLoader: 1.346ms
OBJLoader: 7.295ms
OBJLoader: 8.801ms
```