### PR TITLE
Set max listeners Infinity on EventTarget

### DIFF
--- a/src/Event.js
+++ b/src/Event.js
@@ -6,6 +6,8 @@ class EventTarget extends EventEmitter {
   constructor() {
     super();
 
+    this.setMaxListeners(Infinity);
+
     this.on('error', err => {
       console.warn(err);
     });


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/177.

I think the this should cover the DOM nodes at least, since `Node` is an `EventTarget`.