### PR TITLE
Change test port 3000->10000

### DIFF
--- a/tests/unit/__setup.test.js
+++ b/tests/unit/__setup.test.js
@@ -9,7 +9,7 @@ var core = require('../../core');
 core.setNativeBindingsModule(path.resolve('native-bindings.js'));
 
 global.assert = chai.assert;
-global.TEST_URL = `http://localhost:${PORT}`;
+global.TEST_URL = `http://127.0.0.1:${PORT}`;
 
 const server = express();
 let serverListener;

--- a/tests/unit/__setup.test.js
+++ b/tests/unit/__setup.test.js
@@ -3,11 +3,13 @@ var express = require('express');
 var path = require('path');
 var Sinon = require('sinon');
 
+const PORT = 10000;
+
 var core = require('../../core');
 core.setNativeBindingsModule(path.resolve('native-bindings.js'));
 
 global.assert = chai.assert;
-global.TEST_URL = 'http://localhost:3000';
+global.TEST_URL = `http://localhost:${PORT}`;
 
 const server = express();
 let serverListener;
@@ -15,7 +17,7 @@ let serverListener;
 beforeEach(function (done) {
   this.sinon = Sinon.createSandbox();
   server.use('/', express.static(__dirname + '/data'));
-  serverListener = server.listen(3000, done);
+  serverListener = server.listen(PORT, done);
 });
 
 afterEach(function (done) {


### PR DESCRIPTION
`localhost:3000` was actually vm-routed for me since it's pretty common, causing my tests to fail.

- Use a higher port less likely to be used
- Use `127.0.0.1` to avoid hitting NS for tests