### PR TITLE
Image load AsyncResource

### DIFF
--- a/deps/exokit-bindings/canvascontext/include/image-context.h
+++ b/deps/exokit-bindings/canvascontext/include/image-context.h
@@ -2,6 +2,7 @@
 #define _CANVASCONTEXT_IMAGE_H_
 
 #include <v8.h>
+#include <node.h>
 #include <nan/nan.h>
 #include <defines.h>
 #include <canvas/include/Context.h>

--- a/deps/exokit-bindings/canvascontext/src/image-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/image-context.cc
@@ -56,12 +56,15 @@ void Image::RunInMainThread(uv_async_t *handle) {
   Image *image = (*iter).second;
   handleToImageMap.erase(iter);
 
+  Local<Object> asyncObject = Nan::New<Object>();
+  AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "imageLoad");
+  
   Local<Function> cbFn = Nan::New(image->cbFn);
   Local<String> arg0 = Nan::New<String>(image->error).ToLocalChecked();
   Local<Value> argv[] = {
     arg0,
   };
-  cbFn->Call(Nan::Null(), sizeof(argv)/sizeof(argv[0]), argv);
+  asyncResource.MakeCallback(cbFn, sizeof(argv)/sizeof(argv[0]), argv);
 
   image->cbFn.Reset();
   image->arrayBuffer.Reset();


### PR DESCRIPTION
_*TLDR* if you make a callback from C++ it should be wrapped in `AsyncResource`._

#### Description

We load all images asyncly on a thread. But when we were calling back to user code, we were just calling the callback and that's it.

This works, but the problem is if the user callback sets up more things on the event loop -- like a `Promise` -- then that will be queued but might not run immediately because node doesn't know about it.

That's what `AsyncResource` wrapping alleviates, so `node` knows to check the event loop for more things after the callback.

#### Why it took so long

This passed us by for so long because you usually have another thing to run soon after, and the event loop will flush when that happens. Also if we are running the loop at 90FPS then it's hard to notice any resource lag.

The problem arises when the last thing you are loading for your site is an image or something... Which is common for THREE.js. So the user sees mysterious site loading lag that will get resolved only by chance when some internal timer ticks to flush the loop.

#### Side effects

- makes some image tests run faster (900ms -> 3ms) 🏃 
- less mysterious site loading lag 🦄

Found with https://github.com/webmixedreality/exokit/pull/180.