### PR TITLE
Add WebGL2 vertexAttribIPointer method

### DIFF
--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -142,6 +142,7 @@ public:
   static NAN_METHOD(BlendFunc);
   static NAN_METHOD(EnableVertexAttribArray);
   static NAN_METHOD(VertexAttribPointer);
+  static NAN_METHOD(VertexAttribIPointer);
   static NAN_METHOD(ActiveTexture);
   static NAN_METHOD(DrawElements);
   static NAN_METHOD(DrawElementsInstancedANGLE);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -623,6 +623,7 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(proto, "blendFunc", glCallWrap<BlendFunc>);
   Nan::SetMethod(proto, "enableVertexAttribArray", glCallWrap<EnableVertexAttribArray>);
   Nan::SetMethod(proto, "vertexAttribPointer", glCallWrap<VertexAttribPointer>);
+  Nan::SetMethod(proto, "vertexAttribIPointer", glCallWrap<VertexAttribIPointer>);
   Nan::SetMethod(proto, "activeTexture", glCallWrap<ActiveTexture>);
   Nan::SetMethod(proto, "drawElements", glCallWrap<DrawElements>);
   Nan::SetMethod(proto, "drawElementsInstancedANGLE", glCallWrap<DrawElementsInstancedANGLE>);
@@ -2149,6 +2150,18 @@ NAN_METHOD(WebGLRenderingContext::VertexAttribPointer) {
 
   //    printf("VertexAttribPointer %d %d %d %d %d %d\n", indx, size, type, normalized, stride, offset);
   glVertexAttribPointer(indx, size, type, normalized, stride, (const GLvoid *)offset);
+
+  // info.GetReturnValue().Set(Nan::Undefined());
+}
+
+NAN_METHOD(WebGLRenderingContext::VertexAttribIPointer) {
+  GLuint indx = info[0]->Uint32Value();
+  GLint size = info[1]->Int32Value();
+  GLenum type = info[2]->Uint32Value();
+  GLint stride = info[3]->Int32Value();
+  GLint offset = info[4]->Int32Value();
+
+  glVertexAttribIPointer(indx, size, type, stride, (const GLvoid *)offset);
 
   // info.GetReturnValue().Set(Nan::Undefined());
 }


### PR DESCRIPTION
This one was missing; it's part of WebGL2, needed for a demo.

https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/vertexAttribIPointer