### PR TITLE
WebGL2 support

### DIFF
--- a/core.js
+++ b/core.js
@@ -1243,6 +1243,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.CanvasGradient = CanvasGradient;
   window.CanvasRenderingContext2D = CanvasRenderingContext2D;
   window.WebGLRenderingContext = WebGLRenderingContext;
+  window.WebGL2RenderingContext = WebGL2RenderingContext;
   window.Audio = HTMLAudioElementBound;
   window.MediaRecorder = MediaRecorder;
   window.Document = Document;
@@ -1623,6 +1624,7 @@ exokit.setNativeBindingsModule = nativeBindingsModule => {
   CanvasGradient = bindings.nativeCanvasGradient;
   CanvasRenderingContext2D = GlobalContext.CanvasRenderingContext2D = bindings.nativeCanvasRenderingContext2D;
   WebGLRenderingContext = GlobalContext.WebGLRenderingContext = bindings.nativeGl;
+  WebGL2RenderingContext = GlobalContext.WebGL2RenderingContext = bindings.nativeGl2;
   if (args.frame || args.minimalFrame) {
     WebGLRenderingContext = GlobalContext.WebGLRenderingContext = (OldWebGLRenderingContext => {
       function WebGLRenderingContext() {

--- a/deps/exokit-bindings/bindings/include/bindings.h
+++ b/deps/exokit-bindings/bindings/include/bindings.h
@@ -22,6 +22,7 @@
 #endif
 
 v8::Local<v8::Object> makeGl();
+v8::Local<v8::Object> makeGl2();
 v8::Local<v8::Object> makeImage();
 v8::Local<v8::Object> makeImageData();
 v8::Local<v8::Object> makeImageBitmap();

--- a/deps/exokit-bindings/bindings/src/bindings.cc
+++ b/deps/exokit-bindings/bindings/src/bindings.cc
@@ -11,6 +11,10 @@ Local<Object> makeGl() {
   return WebGLRenderingContext::Initialize(Isolate::GetCurrent());
 }
 
+Local<Object> makeGl2() {
+  return WebGL2RenderingContext::Initialize(Isolate::GetCurrent());
+}
+
 Local<Object> makeImage() {
   Isolate *isolate = Isolate::GetCurrent();
 

--- a/deps/exokit-bindings/canvascontext/src/canvas-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/canvas-context.cc
@@ -1282,7 +1282,10 @@ sk_sp<SkImage> CanvasRenderingContext2D::getImage(Local<Value> arg) {
       } else {
         return nullptr;
       }
-    } else if (otherContextObj->IsObject() && otherContextObj->ToObject()->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"))->StrictEquals(JS_STR("WebGLRenderingContext"))) {
+    } else if (otherContextObj->IsObject() && (
+      otherContextObj->ToObject()->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"))->StrictEquals(JS_STR("WebGLRenderingContext")) ||
+      otherContextObj->ToObject()->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"))->StrictEquals(JS_STR("WebGL2RenderingContext"))
+    )) {
       WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(otherContextObj));
 
       int w, h;

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -265,6 +265,8 @@ public:
     return textureBindings.find(std::make_pair(framebuffer, target)) != textureBindings.end();
   }
 
+  static Nan::Persistent<FunctionTemplate> s_ct;
+
   bool live;
   GLFWwindow *windowHandle;
   bool dirty;
@@ -277,6 +279,19 @@ public:
   std::map<GLenum, GLuint> framebufferBindings;
   std::map<GLenum, GLuint> renderbufferBindings;
   std::map<std::pair<GLenum, GLenum>, GLuint> textureBindings;
+};
+
+class WebGL2RenderingContext : public WebGLRenderingContext {
+public:
+  WebGL2RenderingContext();
+  ~WebGL2RenderingContext();
+
+  static Handle<Object> Initialize(Isolate *isolate);
+
+  static NAN_METHOD(New);
+  static NAN_METHOD(Lol);
+
+  static Nan::Persistent<FunctionTemplate> s_ct;
 };
 
 #endif

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -543,7 +543,10 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
   Nan::EscapableHandleScope scope;
 
   // constructor
-  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(New);
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(WebGLRenderingContext::New);
+
+  s_ct.Reset(ctor);
+
   ctor->InstanceTemplate()->SetInternalFieldCount(1);
   ctor->SetClassName(JS_STR("WebGLRenderingContext"));
 
@@ -3559,6 +3562,48 @@ NAN_METHOD(WebGLRenderingContext::CheckFramebufferStatus) {
 
   info.GetReturnValue().Set(JS_INT(ret));
 }
+
+Nan::Persistent<FunctionTemplate> WebGLRenderingContext::s_ct;
+
+// WebGL2RenderingContext
+
+WebGL2RenderingContext::WebGL2RenderingContext() {}
+
+WebGL2RenderingContext::~WebGL2RenderingContext() {}
+
+Handle<Object> WebGL2RenderingContext::Initialize(Isolate *isolate) {
+  Nan::EscapableHandleScope scope;
+
+  Local<FunctionTemplate> ctor = Nan::New<FunctionTemplate>(WebGL2RenderingContext::New);
+
+  s_ct.Reset(ctor);
+  Local<FunctionTemplate> baseSCT = Nan::New(WebGLRenderingContext::s_ct);
+  ctor->Inherit(baseSCT);
+  ctor->InstanceTemplate()->SetInternalFieldCount(1);
+  ctor->SetClassName(JS_STR("WebGL2RenderingContext"));
+  
+  Local<ObjectTemplate> proto = ctor->PrototypeTemplate();
+  Nan::SetMethod(proto, "lol", Lol);
+
+  Local<Function> ctorFn = ctor->GetFunction();
+  setGlConstants(ctorFn);
+
+  return scope.Escape(ctorFn);
+}
+
+NAN_METHOD(WebGL2RenderingContext::New) {
+  WebGL2RenderingContext *gl2 = new WebGL2RenderingContext();
+  Local<Object> gl2Obj = info.This();
+  gl2->Wrap(gl2Obj);
+
+  info.GetReturnValue().Set(gl2Obj);
+}
+
+NAN_METHOD(WebGL2RenderingContext::Lol) {
+  info.GetReturnValue().Set(JS_STR("zol"));
+}
+
+Nan::Persistent<FunctionTemplate> WebGL2RenderingContext::s_ct;
 
 /* struct GLObj {
   GLObjectType type;

--- a/main.cpp
+++ b/main.cpp
@@ -142,6 +142,9 @@ void Java_com_mafintosh_nodeonandroid_NodeService_onDrawFrame
 void InitExports(Handle<Object> exports) {
   Local<Value> gl = makeGl();
   exports->Set(v8::String::NewFromUtf8(Isolate::GetCurrent(), "nativeGl"), gl);
+  
+  Local<Value> gl2 = makeGl2();
+  exports->Set(v8::String::NewFromUtf8(Isolate::GetCurrent(), "nativeGl2"), gl2);
 
   Local<Value> image = makeImage();
   exports->Set(v8::String::NewFromUtf8(Isolate::GetCurrent(), "nativeImage"), image);

--- a/native-bindings.js
+++ b/native-bindings.js
@@ -62,6 +62,22 @@ bindings.nativeGl = (nativeGl => {
   WebGLRenderingContext.onconstruct = null;
   return WebGLRenderingContext;
 })(bindings.nativeGl);
+bindings.nativeGl2 = (nativeGl2 => {
+  function WebGL2RenderingContext(canvas) {
+    const gl = new nativeGl2();
+    _decorateGlIntercepts(gl);
+    
+    if (WebGLRenderingContext.onconstruct(gl, canvas)) {
+      return gl;
+    } else {
+      return null;
+    }
+  }
+  for (const k in nativeGl2) {
+    WebGL2RenderingContext[k] = nativeGl2[k];
+  }
+  return WebGL2RenderingContext;
+})(bindings.nativeGl2);
 
 const {PannerNode} = nativeAudio;
 PannerNode.setPath(path.join(require.resolve('native-audio-deps').slice(0, -'index.js'.length), 'assets', 'hrtf'));

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1837,13 +1837,17 @@ class HTMLCanvasElement extends HTMLElement {
       if (this._context === null) {
         this._context = new GlobalContext.CanvasRenderingContext2D(this.width, this.height);
       }
-    } else if (contextType === 'webgl' || contextType === 'xrpresent') {
-      if (this._context && this._context.constructor && this._context.constructor.name !== 'WebGLRenderingContext') {
+    } else if (contextType === 'webgl' || contextType === 'webgl2' || contextType === 'xrpresent') {
+      if (this._context && this._context.constructor && this._context.constructor.name !== 'WebGLRenderingContext' && name !== 'WebGL2RenderingContext') {
         this._context.destroy();
         this._context = null;
       }
       if (this._context === null) {
-        this._context = new GlobalContext.WebGLRenderingContext(this);
+        if (contextType === 'webgl') {
+          this._context = new WebGLRenderingContext(this);
+        } else {
+          this._context = new WebGL2RenderingContext(this);
+        }
       }
     } else {
       if (this._context) {


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/52.

This is a lot less of a deal than it sounds. We're just based on OpenGL, so this support is nearly "free", and some of the functionality of `WebGL2RenderingContext` has been exposed for a while.

This just makes it official and allows construction of a `WebGL2RenderingContext` that follows the `WebGLRenderingContext` inheritance chain and otherwise works the same.

The main reason for adding this is to unlock sites that want WebGL 2 for some reason. Or, in my case, emscripten blocking important functionality except in a WebGL2 context.