### PR TITLE
texImage2D WebGL2 overloads

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1821,12 +1821,9 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
       !levelNumber.IsEmpty() && !internalformat.IsEmpty() &&
       !widthNumber.IsEmpty() && !heightNumber.IsEmpty() &&
       !formatNumber.IsEmpty() && !typeNumber.IsEmpty() &&
-      (pixels->IsNull() || pixels->isObject() || pixels->IsNumber())
+      (pixels->IsNull() || pixels->IsArrayBufferView() || pixels->IsNumber())
     ) {
-      /* if (pixels) {
-        pixels = _getImageData(pixels);
-      } */
-      // return _texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+      // nothing
     } else {
       Nan::ThrowError("Expected texImage2D(number target, number level, number internalformat, number width, number height, number border, number format, number type, ArrayBufferView pixels)");
       return;
@@ -2895,9 +2892,7 @@ NAN_METHOD(WebGLRenderingContext::TexSubImage2D) {
   GLenum typeV = info[7]->Int32Value();
   Local<Value> pixels = info[8];
 
-  // int num;
   char *pixelsV;
-
   if (pixels->IsNull()) {
     glTexSubImage2D(targetV, levelV, xoffsetV, yoffsetV, widthV, heightV, formatV, typeV, nullptr);
   } else if ((pixelsV = (char *)getImageData(pixels)) != nullptr) {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1821,7 +1821,7 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
       !levelNumber.IsEmpty() && !internalformat.IsEmpty() &&
       !widthNumber.IsEmpty() && !heightNumber.IsEmpty() &&
       !formatNumber.IsEmpty() && !typeNumber.IsEmpty() &&
-        (pixels->IsNull() || !Nan::To<Object>(pixels).IsEmpty())
+      (pixels->IsNull() || pixels->isObject() || pixels->IsNumber())
     ) {
       /* if (pixels) {
         pixels = _getImageData(pixels);
@@ -1862,14 +1862,14 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
     return;
   }
 
-  int targetV = target->Int32Value();
-  int levelV = level->Int32Value();
-  int internalformatV = internalformat->Int32Value();
-  int widthV = width->Int32Value();
-  int heightV = height->Int32Value();
-  int borderV = border->Int32Value();
-  int formatV = format->Int32Value();
-  int typeV = type->Int32Value();
+  GLenum targetV = target->Uint32Value();
+  GLenum levelV = level->Uint32Value();
+  GLenum internalformatV = internalformat->Uint32Value();
+  GLsizei widthV = width->Uint32Value();
+  GLsizei heightV = height->Uint32Value();
+  GLint borderV = border->Int32Value();
+  GLenum formatV = format->Uint32Value();
+  GLenum typeV = type->Uint32Value();
 
   internalformatV = normalizeInternalFormat(internalformatV, formatV, typeV);
 
@@ -1878,6 +1878,9 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
   char *pixelsV;
   if (pixels->IsNull()) {
     glTexImage2D(targetV, levelV, internalformatV, widthV, heightV, borderV, formatV, typeV, nullptr);
+  } else if (pixels->IsNumber()) {
+    GLintptr offsetV = pixels->Uint32Value();
+    glTexImage2D(targetV, levelV, internalformatV, widthV, heightV, borderV, formatV, typeV, (void *)offsetV);
   } else if ((pixelsV = (char *)getImageData(pixels)) != nullptr) {
     size_t formatSize = getFormatSize(formatV);
     size_t typeSize = getTypeSize(typeV);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1821,7 +1821,7 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
       !levelNumber.IsEmpty() && !internalformat.IsEmpty() &&
       !widthNumber.IsEmpty() && !heightNumber.IsEmpty() &&
       !formatNumber.IsEmpty() && !typeNumber.IsEmpty() &&
-      (pixels->IsNull() || pixels->IsArrayBufferView() || pixels->IsNumber())
+      (pixels->IsNull() || pixels->IsObject() || pixels->IsNumber())
     ) {
       // nothing
     } else {
@@ -1843,14 +1843,14 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
       !widthNumber.IsEmpty() && !heightNumber.IsEmpty() &&
       !formatNumber.IsEmpty() && !typeNumber.IsEmpty()
     ) {
-      if (pixels->IsNull()) {
-        // nothing
-      } else if (pixels->IsObject() && !srcOffsetNumber.IsEmpty()) {
+      if (pixels->IsArrayBufferView() && !srcOffsetNumber.IsEmpty()) {
         Local<ArrayBufferView> arrayBufferView = Local<ArrayBufferView>::Cast(pixels);
         size_t srcOffsetInt = srcOffset->Uint32Value();
         size_t elementSize = getArrayBufferViewElementSize(arrayBufferView);
         size_t extraOffset = srcOffsetInt * elementSize;
         pixels = Uint8Array::New(arrayBufferView->Buffer(), arrayBufferView->ByteOffset() + extraOffset, arrayBufferView->ByteLength() - extraOffset);
+      } else if (pixels->IsNull() || pixels->IsObject()) {
+        // nothing
       } else {
         Nan::ThrowError("Expected texImage2D(number target, number level, number internalformat, number width, number height, number border, number format, number type, ArrayBufferView srcData, number srcOffset)");
         return;

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1846,11 +1846,9 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
 
   internalformatV = normalizeInternalFormat(internalformatV, formatV, typeV);
 
-  // int num;
-  char *pixelsV;
-
   WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(info.This());
 
+  char *pixelsV;
   if (pixels->IsNull()) {
     glTexImage2D(targetV, levelV, internalformatV, widthV, heightV, borderV, formatV, typeV, nullptr);
   } else if ((pixelsV = (char *)getImageData(pixels)) != nullptr) {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1741,6 +1741,18 @@ int getImageFormat(Local<Value> arg) {
   }
 }
 
+size_t getArrayBufferViewElementSize(Local<ArrayBufferView> arrayBufferView) {
+  if (arrayBufferView->IsFloat64Array()) {
+    return 8;
+  } else if (arrayBufferView->IsFloat32Array() || arrayBufferView->IsUint32Array() || arrayBufferView->IsInt32Array()) {
+    return 4;
+  } else if (arrayBufferView->IsUint16Array() || arrayBufferView->IsInt16Array()) {
+    return 2;
+  } else {
+    return 0;
+  }
+}
+
 NAN_METHOD(WebGLRenderingContext::TexImage2D) {
   Isolate *isolate = Isolate::GetCurrent();
 

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1841,15 +1841,20 @@ NAN_METHOD(WebGLRenderingContext::TexImage2D) {
       !targetNumber.IsEmpty() &&
       !levelNumber.IsEmpty() && !internalformat.IsEmpty() &&
       !widthNumber.IsEmpty() && !heightNumber.IsEmpty() &&
-      !formatNumber.IsEmpty() && !typeNumber.IsEmpty() &&
-      (pixels->IsNull() || !Nan::To<Object>(pixels).IsEmpty()) &&
-      !srcOffsetNumber.IsEmpty()
+      !formatNumber.IsEmpty() && !typeNumber.IsEmpty()
     ) {
-      Local<ArrayBufferView> arrayBufferView = Local<ArrayBufferView>::Cast(pixels);
-      size_t srcOffsetInt = srcOffset->Uint32Value();
-      size_t elementSize = getArrayBufferViewElementSize(arrayBufferView);
-      size_t extraOffset = srcOffsetInt * elementSize;
-      pixels = Uint8Array::New(arrayBufferView->Buffer(), arrayBufferView->ByteOffset() + extraOffset, arrayBufferView->ByteLength() - extraOffset);
+      if (pixels->IsNull()) {
+        // nothing
+      } else if (pixels->IsObject() && !srcOffsetNumber.IsEmpty()) {
+        Local<ArrayBufferView> arrayBufferView = Local<ArrayBufferView>::Cast(pixels);
+        size_t srcOffsetInt = srcOffset->Uint32Value();
+        size_t elementSize = getArrayBufferViewElementSize(arrayBufferView);
+        size_t extraOffset = srcOffsetInt * elementSize;
+        pixels = Uint8Array::New(arrayBufferView->Buffer(), arrayBufferView->ByteOffset() + extraOffset, arrayBufferView->ByteLength() - extraOffset);
+      } else {
+        Nan::ThrowError("Expected texImage2D(number target, number level, number internalformat, number width, number height, number border, number format, number type, ArrayBufferView srcData, number srcOffset)");
+        return;
+      }
     } else {
       Nan::ThrowError("Expected texImage2D(number target, number level, number internalformat, number width, number height, number border, number format, number type, ArrayBufferView srcData, number srcOffset)");
       return;


### PR DESCRIPTION
Adds two missing WebGL2 [`texImage2D`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D) overloads:

- `void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, GLuint srcOffset)`
- `void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, GLintptr offset)`