### PR TITLE
Add WebGL2 uniforms methods

### DIFF
--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -219,7 +219,7 @@ public:
 
   static NAN_METHOD(TexSubImage2D);
   static NAN_METHOD(TexStorage2D);
-  
+
   static NAN_METHOD(ReadPixels);
   static NAN_METHOD(GetTexParameter);
   static NAN_METHOD(GetActiveAttrib);
@@ -239,7 +239,7 @@ public:
   static NAN_METHOD(CreateVertexArray);
   static NAN_METHOD(DeleteVertexArray);
   static NAN_METHOD(BindVertexArray);
-  
+
   static NAN_METHOD(FenceSync);
   static NAN_METHOD(DeleteSync);
   static NAN_METHOD(ClientWaitSync);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -100,14 +100,26 @@ public:
   static NAN_METHOD(Uniform2iv);
   static NAN_METHOD(Uniform3iv);
   static NAN_METHOD(Uniform4iv);
+
+  static NAN_METHOD(Uniform1uiv);
+  static NAN_METHOD(Uniform2uiv);
+  static NAN_METHOD(Uniform3uiv);
+  static NAN_METHOD(Uniform4uiv);
+  static NAN_METHOD(UniformMatrix2fv);
+  static NAN_METHOD(UniformMatrix3fv);
+  static NAN_METHOD(UniformMatrix4fv);
+  static NAN_METHOD(UniformMatrix3x2fv);
+  static NAN_METHOD(UniformMatrix4x2fv);
+  static NAN_METHOD(UniformMatrix2x3fv);
+  static NAN_METHOD(UniformMatrix4x3fv);
+  static NAN_METHOD(UniformMatrix2x4fv);
+  static NAN_METHOD(UniformMatrix3x4fv);
+
   static NAN_METHOD(PixelStorei);
   static NAN_METHOD(BindAttribLocation);
   static NAN_METHOD(GetError);
   static NAN_METHOD(DrawArrays);
   static NAN_METHOD(DrawArraysInstanced);
-  static NAN_METHOD(UniformMatrix2fv);
-  static NAN_METHOD(UniformMatrix3fv);
-  static NAN_METHOD(UniformMatrix4fv);
   static NAN_METHOD(GenerateMipmap);
   static NAN_METHOD(GetAttribLocation);
   static NAN_METHOD(DepthFunc);
@@ -163,7 +175,14 @@ public:
   static NAN_METHOD(VertexAttrib2fv);
   static NAN_METHOD(VertexAttrib3fv);
   static NAN_METHOD(VertexAttrib4fv);
+  
+  static NAN_METHOD(VertexAttribI4i);
+  static NAN_METHOD(VertexAttribI4iv);
+  static NAN_METHOD(VertexAttribI4ui);
+  static NAN_METHOD(VertexAttribI4uiv);
+  
   static NAN_METHOD(VertexAttribDivisor);
+
   static NAN_METHOD(DrawBuffersWEBGL);
 
   static NAN_METHOD(BlendColor);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -88,6 +88,10 @@ public:
   static NAN_METHOD(Uniform2i);
   static NAN_METHOD(Uniform3i);
   static NAN_METHOD(Uniform4i);
+  static NAN_METHOD(Uniform1ui);
+  static NAN_METHOD(Uniform2ui);
+  static NAN_METHOD(Uniform3ui);
+  static NAN_METHOD(Uniform4ui);
   static NAN_METHOD(Uniform1fv);
   static NAN_METHOD(Uniform2fv);
   static NAN_METHOD(Uniform3fv);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2802,7 +2802,7 @@ NAN_METHOD(WebGLRenderingContext::VertexAttribI4ui) {
   GLuint v2 = info[3]->Uint32Value();
   GLuint v3 = info[4]->Uint32Value();
 
-  glVertexAttribI4i(index, v0, v1, v2, v3);
+  glVertexAttribI4ui(index, v0, v1, v2, v3);
 }
 
 NAN_METHOD(WebGLRenderingContext::VertexAttribI4uiv) {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1325,8 +1325,6 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix3fv) {
 
   GLfloat *data;
   GLsizei count;
-  // GLfloat* data=getArrayData<GLfloat>(info[2],&count);
-
   if (info[2]->IsArray()) {
     Local<Array> array = Local<Array>::Cast(info[2]);
     unsigned int length = array->Length();
@@ -1344,8 +1342,6 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix3fv) {
   }else{
     count /= 9;
     glUniformMatrix3fv(location, count, transpose, data);
-
-    // info.GetReturnValue().Set(Nan::Undefined());
   }
 }
 
@@ -1355,8 +1351,6 @@ NAN_METHOD(WebGLRenderingContext::UniformMatrix4fv) {
 
   GLfloat *data;
   GLsizei count;
-  // GLfloat* data=getArrayData<GLfloat>(info[2],&count);
-
   if (info[2]->IsArray()) {
     Local<Array> array = Local<Array>::Cast(info[2]);
     unsigned int length = array->Length();

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2487,8 +2487,6 @@ NAN_METHOD(WebGLRenderingContext::VertexAttribDivisor) {
   GLuint divisor = info[1]->Uint32Value();
 
   glVertexAttribDivisor(index, divisor);
-
-  // info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(WebGLRenderingContext::DrawBuffersWEBGL) {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -590,6 +590,10 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(proto, "uniform2i", glCallWrap<Uniform2i>);
   Nan::SetMethod(proto, "uniform3i", glCallWrap<Uniform3i>);
   Nan::SetMethod(proto, "uniform4i", glCallWrap<Uniform4i>);
+  Nan::SetMethod(proto, "uniform1ui", glCallWrap<Uniform1ui>);
+  Nan::SetMethod(proto, "uniform2ui", glCallWrap<Uniform2ui>);
+  Nan::SetMethod(proto, "uniform3ui", glCallWrap<Uniform3ui>);
+  Nan::SetMethod(proto, "uniform4ui", glCallWrap<Uniform4ui>);
   Nan::SetMethod(proto, "uniform1fv", glCallWrap<Uniform1fv>);
   Nan::SetMethod(proto, "uniform2fv", glCallWrap<Uniform2fv>);
   Nan::SetMethod(proto, "uniform3fv", glCallWrap<Uniform3fv>);
@@ -997,6 +1001,48 @@ NAN_METHOD(WebGLRenderingContext::Uniform4i) {
     GLint y = info[2]->Int32Value();
     GLint z = info[3]->Int32Value();
     GLint w = info[4]->Int32Value();
+
+    glUniform4i(location, x, y, z, w);
+  }
+}
+
+NAN_METHOD(WebGLRenderingContext::Uniform1ui) {
+  if (info[0]->IsObject()) {
+    GLuint location = info[0]->ToObject()->Get(JS_STR("id"))->Uint32Value();
+    GLuint x = info[1]->Int32Value();
+
+    glUniform1i(location, x);
+  }
+}
+
+NAN_METHOD(WebGLRenderingContext::Uniform2ui) {
+  if (info[0]->IsObject()) {
+    GLuint location = info[0]->ToObject()->Get(JS_STR("id"))->Uint32Value();
+    GLuint x = info[1]->Int32Value();
+    GLuint y = info[2]->Int32Value();
+
+    glUniform2i(location, x, y);
+  }
+}
+
+NAN_METHOD(WebGLRenderingContext::Uniform3ui) {
+  if (info[0]->IsObject()) {
+    GLuint location = info[0]->ToObject()->Get(JS_STR("id"))->Uint32Value();
+    GLuint x = info[1]->Int32Value();
+    GLuint y = info[2]->Int32Value();
+    GLuint z = info[3]->Int32Value();
+
+    glUniform3i(location, x, y, z);
+  }
+}
+
+NAN_METHOD(WebGLRenderingContext::Uniform4ui) {
+  if (info[0]->IsObject()) {
+    GLuint location = info[0]->ToObject()->Get(JS_STR("id"))->Uint32Value();
+    GLuint x = info[1]->Int32Value();
+    GLuint y = info[2]->Int32Value();
+    GLuint z = info[3]->Int32Value();
+    GLuint w = info[4]->Int32Value();
 
     glUniform4i(location, x, y, z, w);
   }


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/207.

These were mostly added for performance/portability to OpenGL 3: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7. Not much interesting here, they're just straight up OpenGL bindings.

Needed to round out OpenGL3 compilation support for emscripten 🖼