### PR TITLE
Make WebGL getParameter return correct zero

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -3701,9 +3701,13 @@ NAN_METHOD(WebGLRenderingContext::GetParameter) {
       GLint param;
       glGetIntegerv(name, &param);
 
-      Local<Object> object = Nan::New<Object>();
-      object->Set(JS_STR("id"), JS_INT(param));
-      info.GetReturnValue().Set(object);
+      if (param != 0) {
+        Local<Object> object = Nan::New<Object>();
+        object->Set(JS_STR("id"), JS_INT(param));
+        info.GetReturnValue().Set(object);
+      } else {
+        info.GetReturnValue().Set(Nan::Null());
+      }
       break;
     }
     case GL_COMPRESSED_TEXTURE_FORMATS:


### PR DESCRIPTION
If there is no binding for one of these, we should return `null`.

```
     case GL_ARRAY_BUFFER_BINDING:	     case GL_ARRAY_BUFFER_BINDING:
     case GL_ELEMENT_ARRAY_BUFFER_BINDING:	     case GL_ELEMENT_ARRAY_BUFFER_BINDING:
     case GL_FRAMEBUFFER_BINDING:	     case GL_FRAMEBUFFER_BINDING:
     case GL_RENDERBUFFER_BINDING:	     case GL_RENDERBUFFER_BINDING:
     case GL_TEXTURE_BINDING_2D:	     case GL_TEXTURE_BINDING_2D:
     case GL_TEXTURE_BINDING_CUBE_MAP:	     case GL_TEXTURE_BINDING_CUBE_MAP:
     case GL_ACTIVE_TEXTURE:	     case GL_ACTIVE_TEXTURE:
     case GL_CURRENT_PROGRAM:
```

The old behavior was to return an object with `{id: 0}` in this, which was not correct and was confusing sites.