### PR TITLE
Return WebGL2 version

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -3615,7 +3615,7 @@ NAN_METHOD(WebGLRenderingContext::GetParameter) {
     }
     case GL_VERSION:
     {
-      Local<Value> constructorName = info.This()->ToObject()->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"));
+      Local<Value> constructorName = info.This()->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"));
       if (constructorName->StrictEquals(JS_STR("WebGL2RenderingContext"))) {
         info.GetReturnValue().Set(JS_STR("WebGL 2"));
       } else {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -3615,8 +3615,12 @@ NAN_METHOD(WebGLRenderingContext::GetParameter) {
     }
     case GL_VERSION:
     {
-      info.GetReturnValue().Set(JS_STR("WebGL 1"));
-
+      Local<Value> constructorName = info.This()->ToObject()->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"));
+      if (constructorName->StrictEquals(JS_STR("WebGL2RenderingContext"))) {
+        info.GetReturnValue().Set(JS_STR("WebGL 2"));
+      } else {
+        info.GetReturnValue().Set(JS_STR("WebGL 1"));
+      }
       break;
     }
     case GL_MAX_VIEWPORT_DIMS:


### PR DESCRIPTION
`'WebGL 2'` if in a `WebGL2RenderingContext`, `'WebGL 1'` otherwise.

I've seen sites check for this 🤷.