### PR TITLE
remove enter vr button / overlay click detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,21 +476,7 @@ nativeWindow.setEventHandler((type, data) => {
       case 'mousedown':
       case 'mouseup':
       case 'click': {
-        const e = new window.MouseEvent(type, data);
-
-        // XXX The overlay detection here is a hack.
-        // It's only needed because sibling overlay elements sometimes expect to capture events instead of the canvas.
-        // The correct way to handle this is to compute actual layout with something like reworkcss + Yoga.
-        let dispatchEl = null;
-        if (!window.document.pointerLockElement && !vrPresentState.isPresenting && (dispatchEl = window.document.documentElement.traverse(el => {
-          if (el.nodeType === 1 && (el.tagName === 'BUTTON' || window.getComputedStyle(el).cursor === 'pointer')) {
-            return el;
-          }
-        }))) {
-          dispatchEl.dispatchEvent(e);
-        }
-
-        canvas.dispatchEvent(e);
+        canvas.dispatchEvent(new window.MouseEvent(type, data));
         break;
       }
       case 'wheel': {


### PR DESCRIPTION
- This code was causing multi-second delays on each click for my A-Frame apps.
- Prescribe all sites to have an activation event, for a vr browser. aframe and more recently three.js now listen to the events out of the box.