### PR TITLE
Default VAO zero

### DIFF
--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -1346,14 +1346,15 @@ NAN_METHOD(Create) {
       glGenVertexArrays(1, &vao);
       glBindVertexArray(vao);
 
-      Local<Array> result = Nan::New<Array>(7);
+      Local<Array> result = Nan::New<Array>(8);
       result->Set(0, pointerToArray(windowHandle));
-      result->Set(1, JS_NUM(framebuffers[0]));
-      result->Set(2, JS_NUM(framebufferTextures[0]));
-      result->Set(3, JS_NUM(framebufferTextures[1]));
-      result->Set(4, JS_NUM(framebuffers[1]));
-      result->Set(5, JS_NUM(framebufferTextures[2]));
-      result->Set(6, JS_NUM(framebufferTextures[3]));
+      result->Set(1, JS_INT(framebuffers[0]));
+      result->Set(2, JS_INT(framebufferTextures[0]));
+      result->Set(3, JS_INT(framebufferTextures[1]));
+      result->Set(4, JS_INT(framebuffers[1]));
+      result->Set(5, JS_INT(framebufferTextures[2]));
+      result->Set(6, JS_INT(framebufferTextures[3]));
+      result->Set(7, JS_INT(vao));
       info.GetReturnValue().Set(result);
     } else {
       /* Problem: glewInit failed, something is seriously wrong. */

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -77,6 +77,7 @@ public:
   static NAN_METHOD(Destroy);
   static NAN_METHOD(GetWindowHandle);
   static NAN_METHOD(SetWindowHandle);
+  static NAN_METHOD(SetDefaultVao);
   static NAN_METHOD(IsDirty);
   static NAN_METHOD(ClearDirty);
 
@@ -307,6 +308,7 @@ public:
 
   bool live;
   GLFWwindow *windowHandle;
+  GLuint defaultVao;
   bool dirty;
   GLuint defaultFramebuffer;
   bool flipY;

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -615,6 +615,7 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(proto, "destroy", Destroy);
   Nan::SetMethod(proto, "getWindowHandle", GetWindowHandle);
   Nan::SetMethod(proto, "setWindowHandle", SetWindowHandle);
+  Nan::SetMethod(proto, "setDefaultVao", SetDefaultVao);
   Nan::SetMethod(proto, "isDirty", IsDirty);
   Nan::SetMethod(proto, "clearDirty", ClearDirty);
 
@@ -826,6 +827,7 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
 WebGLRenderingContext::WebGLRenderingContext() :
   live(true),
   windowHandle(nullptr),
+  defaultVao(0),
   dirty(false),
   defaultFramebuffer(0),
   flipY(true),
@@ -866,6 +868,11 @@ NAN_METHOD(WebGLRenderingContext::SetWindowHandle) {
   } else {
     gl->windowHandle = nullptr;
   }
+}
+
+NAN_METHOD(WebGLRenderingContext::SetDefaultVao) {
+  WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(info.This());
+  gl->defaultVao = info[0]->Uint32Value();
 }
 
 NAN_METHOD(WebGLRenderingContext::IsDirty) {

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -823,7 +823,17 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
   return scope.Escape(ctorFn);
 }
 
-WebGLRenderingContext::WebGLRenderingContext() : live(true), windowHandle(nullptr), dirty(false), defaultFramebuffer(0), flipY(true), premultiplyAlpha(true), packAlignment(4), unpackAlignment(4), activeTexture(GL_TEXTURE0) {}
+WebGLRenderingContext::WebGLRenderingContext() :
+  live(true),
+  windowHandle(nullptr),
+  dirty(false),
+  defaultFramebuffer(0),
+  flipY(true),
+  premultiplyAlpha(true),
+  packAlignment(4),
+  unpackAlignment(4),
+  activeTexture(GL_TEXTURE0)
+  {}
 
 WebGLRenderingContext::~WebGLRenderingContext() {}
 

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -4162,7 +4162,8 @@ NAN_METHOD(WebGLRenderingContext::DeleteVertexArray) {
 }
 
 NAN_METHOD(WebGLRenderingContext::BindVertexArray) {
-  GLuint vao = info[0]->IsObject() ? info[0]->ToObject()->Get(JS_STR("id"))->Uint32Value() : 0;
+  WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(info.This());
+  GLuint vao = info[0]->IsObject() ? info[0]->ToObject()->Get(JS_STR("id"))->Uint32Value() : gl->defaultVao;
 
   glBindVertexArray(vao);
 }

--- a/index.js
+++ b/index.js
@@ -103,9 +103,10 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
     }
   })();
   if (windowSpec) {
-    const [windowHandle, sharedFramebuffer, sharedColorTexture, sharedDepthStencilTexture, sharedMsFramebuffer, sharedMsColorTexture, sharedMsDepthStencilTexture] = windowSpec;
+    const [windowHandle, sharedFramebuffer, sharedColorTexture, sharedDepthStencilTexture, sharedMsFramebuffer, sharedMsColorTexture, sharedMsDepthStencilTexture, vao] = windowSpec;
 
     gl.setWindowHandle(windowHandle);
+    gl.setDefaultVao(vao);
 
     gl.canvas = canvas;
 


### PR DESCRIPTION
OpenGL, which we are based on, requires a vertex array object (VAO) to be bound before you can do anything meaningful with shaders. But WebGL does not require that.

So we've been auto-generating a vao and binding it for the user on context create: https://github.com/webmixedreality/exokit/blob/793eb4919792709c21e43a1e3adcc43c6e52a4ed/deps/exokit-bindings/glfw/src/glfw.cc#L1347

This works fine for WebGL1 where the user cannot touch VAOs anyway (no API for it). But WebGL2 adds [gl.createVertexArray](https://github.com/webmixedreality/exokit/blob/793eb4919792709c21e43a1e3adcc43c6e52a4ed/deps/exokit-bindings/glfw/src/glfw.cc#L1347) and friends, so VAO control becomes important.

#### Problem

The problem is when the user unbinds to a null VAO and has made their context unusable (OpenGL will start erroring). This probably isn't that common in WebGL2 code but it's a common thing done by emscripten compiles.

#### Solution

To solve this we introduce the concept of default VAO (same as the old one) and set it when the user tries to bind to VAO zero.

#### Todo

This isn't a 100% solution because the GL API allows you to check what the currently bound VAO is and in this case it will return non-zero even after the user has bound zero. I think this is a corner case though, since asking GL for what you bound is not recommended. But in the future we should enumerate all of the places this info could leak and patch it up.