### PR TITLE
Add WebGL2 bufferData garbage-free

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2657,7 +2657,7 @@ NAN_METHOD(WebGLRenderingContext::BufferSubData) {
     data = (char *)arrayBuffer->GetContents().Data();
     size = arrayBuffer->ByteLength();
   } else {
-    Nan::ThrowError("Invalid texture argument");
+    Nan::ThrowError("bufferSubData: invalid arguments");
     return;
   }
 


### PR DESCRIPTION
This adds the WebGL2 garbage-free endpoint. See https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bufferData

```
void gl.bufferData(target, ArrayBufferView srcData, usage, srcOffset, length);
```

This gives us enough for a full emscripten webgl2 renderchain.