### PR TITLE
Remove some node globals from window exposure

### DIFF
--- a/core.js
+++ b/core.js
@@ -778,11 +778,15 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
 
   const windowStartScript = `(() => {
     ${!args.require ? 'global.require = undefined;' : ''}
+
     const _logStack = err => {
       console.warn(err);
     };
     process.on('uncaughtException', _logStack);
     process.on('unhandledRejection', _logStack);
+
+    global.process = undefined;
+    global.setImmediate = undefined;
   })();`;
 
   for (const k in EventEmitter.prototype) {


### PR DESCRIPTION
I've seen detection for these in the wild, making built modules think that they are running in node. Which is true but it's not supposed to seem true.

- Setting `process` and `setImmediate` to `undefined` in a window context