### PR TITLE
Update CI to node 10.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ matrix:
     - brew install glfw glew
     install:
     - npm install -g appdmg
-    - curl "https://nodejs.org/dist/v10.4.1/node-v10.4.1-darwin-x64.tar.gz" >node.tar.gz
+    - curl "https://nodejs.org/dist/v10.6.0/node-v10.6.0-darwin-x64.tar.gz" >node.tar.gz
     - tar -zxf node.tar.gz
     - rm node.tar.gz
-    - mv node-v10.4.1-darwin-x64 node
+    - mv node-v10.6.0-darwin-x64 node
     - export PATH="$(pwd)/node/bin:$PATH"
     - unset NVM_NODEJS_ORG_MIRROR
     - "./node/bin/npm install"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ ADD . /app
 WORKDIR /app
 
 RUN \
-  wget "https://nodejs.org/dist/v10.4.1/node-v10.4.1-linux-x64.tar.gz" -O node.tar.gz && \
+  wget "https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-x64.tar.gz" -O node.tar.gz && \
   tar -zxf node.tar.gz && \
   rm node.tar.gz && \
-  mv node-v10.4.1-linux-x64 node
+  mv node-v10.6.0-linux-x64 node
 RUN \
   export PATH="$PATH:$(pwd)/node/bin" && \
   if [ ! -z "$MAGICLEAP_ENV" ]; then export MAGICLEAP="$MAGICLEAP_ENV"; fi && \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,10 @@ test_script:
 
 after_test:
   - ps: |
-      wget "https://nodejs.org/dist/v10.4.1/node-v10.4.1-win-x64.zip" -OutFile node.zip
+      wget "https://nodejs.org/dist/v10.6.0/node-v10.6.0-win-x64.zip" -OutFile node.zip
       7z x node.zip
       rm node.zip
-      mv node-v10.4.1-win-x64 node
+      mv node-v10.6.0-win-x64 node
       $env:Path = "$pwd\node;$env:Path";
       .\node\npm install
       .\node\npm run test:ci


### PR DESCRIPTION
This brings in worker threads, so we can experiment with stopping using `window-worker`. That should be perf++ but more importantly stability++ since it wouldn't be a custom hack.