### PR TITLE
Keep dataPath across window navigation

### DIFF
--- a/core.js
+++ b/core.js
@@ -1505,7 +1505,9 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   let loading = false;
   window.location.on('update', href => {
     if (!loading) {
-      exokit.load(href)
+      exokit.load(href, {
+        dataPath: options.dataPath,
+      })
         .then(newWindow => {
           window._emit('beforeunload');
           window._emit('unload');


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/229.

The bug here was that the `dataPath` option was not threaded to `window.location` reloads, causing `localStorage` (among other things) to default to the `__dirname` for storage.

In the case of an install that's not correct, and also possibly not even writeable (such as on linux).