### PR TITLE
Bugfix requestAnimationFrame chaining

### DIFF
--- a/core.js
+++ b/core.js
@@ -731,7 +731,7 @@ function tickAnimationFrame() {
     }
   }
   
-  _clearLocalCbs();
+  _clearLocalCbs(); // release garbage
 }
 tickAnimationFrame.window = null;
 const _findFreeSlot = a => {

--- a/core.js
+++ b/core.js
@@ -680,7 +680,10 @@ function tickAnimationFrame() {
       if (rafCb && rafCb[symbols.windowSymbol].document.hidden) {
         rafCb(performanceNow);
 
-        rafCbs[i] = null;
+        const index = rafCbs.indexOf(rafCb); // could have changed due to sorting
+        if (index !== -1) {
+          rafCbs[index] = null;
+        }
       }
     }
     // visible rafs
@@ -689,7 +692,10 @@ function tickAnimationFrame() {
       if (rafCb && !rafCb[symbols.windowSymbol].document.hidden) {
         rafCb(performanceNow);
 
-        rafCbs[i] = null;
+        const index = rafCbs.indexOf(rafCb); // could have changed due to sorting
+        if (index !== -1) {
+          rafCbs[index] = null;
+        }
       }
     }
 


### PR DESCRIPTION
A corner case from the optimizations in https://github.com/webmixedreality/exokit/pull/224.

Basically a recursive `requestAnimationFrame` in the wrong order would result in the rAF being called immediately on the same frame. This occurs when the rAF cache state is e.g. `[fn, null]` and you rAF from _inside_ of `fn`.

This is not correct behavior; the caller certainly does not expect a recursive rAF to fire immediately again on the same frame, resulting in a too fast render loop. Not that this does _not_ result in an infinite loop though, since eventually the first rAF slot would become `null` and additional rAFs would be correctly deferred to the next frame.

The fix is to add an extra array during rAF/timeout processing to freeze the set of functions and prevent changes to the set from being picked up in the current frame tick.