### PR TITLE
Add WebGL version flag

### DIFF
--- a/core.js
+++ b/core.js
@@ -1337,7 +1337,9 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.CanvasGradient = CanvasGradient;
   window.CanvasRenderingContext2D = CanvasRenderingContext2D;
   window.WebGLRenderingContext = WebGLRenderingContext;
-  window.WebGL2RenderingContext = WebGL2RenderingContext;
+  if (GlobalContext.args.webgl !== '1') {
+    window.WebGL2RenderingContext = WebGL2RenderingContext;
+  }
   window.Audio = HTMLAudioElementBound;
   window.MediaRecorder = MediaRecorder;
   window.Document = Document;

--- a/core.js
+++ b/core.js
@@ -64,8 +64,6 @@ const _requestBrowser = async () => {
 };
 
 let nativeBindings = false;
-let args = {};
-let version = '';
 
 const btoa = s => Buffer.from(s, 'binary').toString('base64');
 const atob = s => Buffer.from(s, 'base64').toString('binary');
@@ -838,7 +836,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.vm = vmo;
 
   const windowStartScript = `(() => {
-    ${!args.require ? 'global.require = undefined;' : ''}
+    ${!GlobalContext.args.require ? 'global.require = undefined;' : ''}
 
     const _logStack = err => {
       console.warn(err);
@@ -876,7 +874,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   });
   window.history = new History(location.href);
   window.navigator = {
-    userAgent: `MixedReality (Exokit ${version})`,
+    userAgent: `MixedReality (Exokit ${GlobalContext.version})`,
     platform: os.platform(),
     appCodeName: 'Mozilla',
     appName: 'Netscape',
@@ -941,14 +939,14 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   };
 
   // WebVR enabled.
-  if (['all', 'webvr'].includes(args.xr)) {
+  if (['all', 'webvr'].includes(GlobalContext.args.xr)) {
     window.navigator.getVRDisplays = function() {
       return Promise.resolve(this.getVRDisplaysSync());
     }
   }
 
   // WebXR enabled.
-  if (['all', 'webxr'].includes(args.xr)) {
+  if (['all', 'webxr'].includes(GlobalContext.args.xr)) {
     window.navigator.xr = new XR.XR(window);
   }
 
@@ -1719,10 +1717,10 @@ exokit.load = (src, options = {}) => {
 exokit.getAllGamepads = getAllGamepads;
 exokit.THREE = THREE;
 exokit.setArgs = newArgs => {
-  args = newArgs;
+  GlobalContext.args = newArgs;
 };
 exokit.setVersion = newVersion => {
-  version = newVersion;
+  GlobalContext.version = newVersion;
 };
 
 /**
@@ -1756,16 +1754,16 @@ exokit.setNativeBindingsModule = nativeBindingsModule => {
   CanvasRenderingContext2D = GlobalContext.CanvasRenderingContext2D = bindings.nativeCanvasRenderingContext2D;
   WebGLRenderingContext = GlobalContext.WebGLRenderingContext = bindings.nativeGl;
   WebGL2RenderingContext = GlobalContext.WebGL2RenderingContext = bindings.nativeGl2;
-  if (args.frame || args.minimalFrame) {
+  if (GlobalContext.args.frame || GlobalContext.args.minimalFrame) {
     WebGLRenderingContext = GlobalContext.WebGLRenderingContext = (OldWebGLRenderingContext => {
       function WebGLRenderingContext() {
         const result = Reflect.construct(bindings.nativeGl, arguments);
         for (const k in result) {
           if (typeof result[k] === 'function') {
             result[k] = (old => function() {
-              if (args.frame) {
+              if (GlobalContext.args.frame) {
                 console.log(k, arguments);
-              } else if (args.minimalFrame) {
+              } else if (GlobalContext.args.minimalFrame) {
                 console.log(k);
               }
               return old.apply(this, arguments);

--- a/core.js
+++ b/core.js
@@ -41,6 +41,9 @@ const GlobalContext = require('./src/GlobalContext');
 const symbols = require('./src/symbols');
 const {urls} = require('./src/urls');
 
+GlobalContext.args = {};
+GlobalContext.version = '';
+
 // Class imports.
 const {_parseDocument, _parseDocumentAst, Document, DocumentFragment, DocumentType,
        DOMImplementation, initDocument} = require('./src/Document');

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ const args = (() => {
       ],
       string: [
         'tab',
+        'webgl',
         'xr',
         'size',
         'image',
@@ -55,6 +56,7 @@ const args = (() => {
         v: 'version',
         h: 'home',
         t: 'tab',
+        w: 'webgl',
         x: 'xr',
         p: 'performance',
         perf: 'performance',
@@ -72,6 +74,7 @@ const args = (() => {
       url: minimistArgs._[0] || '',
       home: minimistArgs.home || !!minimistArgs.tab,
       tab: minimistArgs.tab,
+      webgl: minimistArgs.webgl || '2',
       xr: minimistArgs.xr || 'all',
       performance: !!minimistArgs.performance,
       size: minimistArgs.size,

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1843,10 +1843,16 @@ class HTMLCanvasElement extends HTMLElement {
         this._context = null;
       }
       if (this._context === null) {
-        if (contextType === 'webgl') {
-          this._context = new WebGLRenderingContext(this);
+        if (GlobalContext.args.webgl === '1') {
+          if (contextType === 'webgl' || contextType === 'xrpresent') {
+            this._context = new WebGLRenderingContext(this);
+          }
         } else {
-          this._context = new WebGL2RenderingContext(this);
+          if (contextType === 'webgl') {
+            this._context = new WebGLRenderingContext(this);
+          } else {
+            this._context = new WebGL2RenderingContext(this);
+          }
         }
       }
     } else {


### PR DESCRIPTION
This is helpful for testing sites that do feature detection.

- Move `args` and `version` context from `core.js` closure to `GlobalContext`
- Add `webgl`/`w` flag to select WebGL2 exposure