### PR TITLE
Add rAF/timeout/interval defaults

### DIFF
--- a/core.js
+++ b/core.js
@@ -973,10 +973,11 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       timeouts[index] = null;
     }
   };
-  window.setInterval = (fn, interval, args) => {
-    if (args) {
-      fn = fn.bind.apply(fn, [window].concat(args));
+  window.setInterval = (fn, interval = 10, args = []) => {
+    if (interval < 10) {
+      interval = 10;
     }
+    fn = fn.bind.apply(fn, [window].concat(args));
     fn[symbols.windowSymbol] = window;
     fn[symbols.startTimeSymbol] = Date.now();
     fn[symbols.intervalSymbol] = interval;

--- a/core.js
+++ b/core.js
@@ -749,10 +749,8 @@ const _findFreeSlot = a => {
   }
   return i;
 };
-const _makeRequestAnimationFrame = window => (fn, priority) => {
-  if (priority === undefined) {
-    priority = 0;
-  }
+const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
+  fn = fn.bind(window);
   fn[symbols.windowSymbol] = window;
   fn[symbols.prioritySymbol] = priority;
   const id = ++rafIndex;

--- a/core.js
+++ b/core.js
@@ -957,10 +957,8 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   };
   window.URL = URL;
   window.console = console;
-  window.setTimeout = (fn, timeout, args) => {
-    if (args) {
-      fn = fn.bind.apply(fn, [window].concat(args));
-    }
+  window.setTimeout = (fn, timeout = 0, args = []) => {
+    fn = fn.bind.apply(fn, [window].concat(args));
     fn[symbols.windowSymbol] = window;
     fn[symbols.startTimeSymbol] = Date.now();
     fn[symbols.timeoutSymbol] = timeout;


### PR DESCRIPTION
This fixes some spec corener cases with the `requestAnimationFrame`,`setTimeout`, and `setInterval` implementation.

- Bind `requestAnimationFrame` callback to `window`
- Default `setTimeout` delay argument to `0`
- Make `setInterval` delay at least `10` per https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval

Fixes [A-Painter](https://aframe.io/a-painter)