### PR TITLE
Worker fixes

### DIFF
--- a/core.js
+++ b/core.js
@@ -1390,7 +1390,6 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.createImageBitmap = createImageBitmap;
   window.Worker =  class Worker extends nativeWorker {
     constructor(src, workerOptions = {}) {
-      workerOptions.baseUrl = options.baseUrl;
       if (nativeBindings) {
         workerOptions.startScript = `
           ${windowStartScript}

--- a/core.js
+++ b/core.js
@@ -206,9 +206,7 @@ class CustomElementRegistry {
 }
 
 let nativeVm = GlobalContext.nativeVm = null;
-class nativeWorker {
-  terminate() {}
-}
+let nativeWorker = null;
 
 class Screen {
   constructor(window) {

--- a/core.js
+++ b/core.js
@@ -1392,16 +1392,18 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     constructor(src, workerOptions = {}) {
       if (nativeBindings) {
         workerOptions.startScript = `
-          ${windowStartScript}
+          (() => {
+            ${windowStartScript}
 
-          const bindings = requireNative("nativeBindings");
-          const smiggles = require("smiggles");
+            const bindings = requireNative("nativeBindings");
+            const smiggles = require("smiggles");
 
-          smiggles.bind({ImageBitmap: bindings.nativeImageBitmap});
+            smiggles.bind({ImageBitmap: bindings.nativeImageBitmap});
 
-          global.Image = bindings.nativeImage;
-          global.ImageBitmap = bindings.nativeImageBitmap;
-          global.createImageBitmap = ${createImageBitmap.toString()};
+            global.Image = bindings.nativeImage;
+            global.ImageBitmap = bindings.nativeImageBitmap;
+            global.createImageBitmap = ${createImageBitmap.toString()};
+          })();
         `;
       }
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "window-fetch": "0.0.9",
     "window-selector": "0.0.5",
     "window-text-encoding": "0.0.2",
-    "window-worker": "0.0.68",
+    "window-worker": "0.0.69",
     "window-xhr": "0.0.19",
     "ws": "^5.2.2"
   },


### PR DESCRIPTION
Fixes a couple of [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker) implementation issues:

- Workers were not based on the `baseUrl` of the script path as they should be (instead they inherited the `baseUrl` of the owning page which is not correct)
- `removeEventListener` was missing on both the parent and child
- `process.argv[0]` was used in the child but `process` no longer exists in user context, so instead we pass in the `process.argv0` from the parent