### PR TITLE
Bugfix FileReader load events to be actual Events

### DIFF
--- a/core.js
+++ b/core.js
@@ -519,7 +519,9 @@ class FileReader extends EventTarget {
     this.result = file.buffer.buffer.slice(file.buffer.byteOffset, file.buffer.byteOffset + file.buffer.byteLength);
 
     process.nextTick(() => {
-      this.emit('load');
+      this.dispatchEvent(new Event('load', {
+        target: this,
+      }));
     });
   }
 
@@ -527,7 +529,9 @@ class FileReader extends EventTarget {
     this.result = 'data:' + file.type + ';base64,' + file.buffer.toString('base64');
 
     process.nextTick(() => {
-      this.emit('load');
+      this.dispatchEvent(new Event('load', {
+        target: this,
+      }));
     });
   }
 }


### PR DESCRIPTION
The `e.target` was being used by [`zip.js` Worker mode](https://github.com/gildas-lormeau/zip.js/blob/3e7920810f63d5057ef6028833243105521da369/WebContent/zip.js#L180)

- Emit an actual `load` `Event` for `FileReader` loading