### PR TITLE
Add logfile support

### DIFF
--- a/exokit-macos
+++ b/exokit-macos
@@ -14,4 +14,4 @@ if [ -x "$DIR/node/bin/node" ]; then
 fi
 
 cd "$DIR"
-exec "$NODE_BIN" "$DIR/index.js" "${@:--h}"
+exec "$NODE_BIN" "$DIR/index.js" "${@:--h -l}"

--- a/exokit.iss
+++ b/exokit.iss
@@ -48,7 +48,7 @@ Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescrip
 Source: "{#ProjectRoot}\*"; DestDir: "{app}"; BeforeInstall: PreInstall; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "\dist"
 
 [Icons]
-Name: "{group}\{#MyAppName}"; WorkingDir: "{%userprofile}"; Filename: "{app}\{#MyAppExeName}"; Parameters: "-h"; IconFilename: "{app}\{#MyIcon}"
+Name: "{group}\{#MyAppName}"; WorkingDir: "{%userprofile}"; Filename: "{app}\{#MyAppExeName}"; Parameters: "-h -l"; IconFilename: "{app}\{#MyIcon}"
 Name: "{group}\{#MyAppShortName} Command Prompt"; WorkingDir: "{%userprofile}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\{#MyIcon}"
 Name: "{group}\Uninstall {#MyAppShortName}"; Filename: "{uninstallexe}"
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const args = (() => {
       boolean: [
         'version',
         'home',
+        'log',
         'perf',
         'performance',
         'frame',
@@ -55,6 +56,7 @@ const args = (() => {
       alias: {
         v: 'version',
         h: 'home',
+        l: 'log',
         t: 'tab',
         w: 'webgl',
         x: 'xr',
@@ -73,6 +75,7 @@ const args = (() => {
       version: minimistArgs.version,
       url: minimistArgs._[0] || '',
       home: minimistArgs.home || !!minimistArgs.tab,
+      log: minimistArgs.log,
       tab: minimistArgs.tab,
       webgl: minimistArgs.webgl || '2',
       xr: minimistArgs.xr || 'all',
@@ -1392,6 +1395,10 @@ if (require.main === module) {
     });
     process.exit(1);
   });
+  if (args.log) {
+    const RedirectOutput = require('redirect-output').default;
+    new RedirectOutput().write(path.join(dataPath, 'log.txt'));
+  }
 
   const _logStack = err => {
     console.warn(err);

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "parse-int": "^1.0.2",
     "parse5": "^5.0.0",
     "puppeteer": "^1.6.0",
+    "redirect-output": "^1.0.0",
     "repl.history": "^0.1.4",
     "rimraf": "^2.6.2",
     "upng-js": "^2.1.0",


### PR DESCRIPTION
In some cases like the MacOS app there is no easy way to launch the console, and "console disappears" is a common Windows complaint.

This adds a `-l` flag that logs stdio to `$(EXOKIT_DATA_DIR)/log.txt`, and enables it by default for the installer-ed launchers.