### PR TITLE
Do not replace exokit.load url unless no protocol

### DIFF
--- a/core.js
+++ b/core.js
@@ -1696,7 +1696,7 @@ const exokit = (s = '', options = {}) => {
   return _makeWindowWithDocument(s, options);
 };
 exokit.load = (src, options = {}) => {
-  if (src.indexOf('://') === -1) {
+  if (!url.parse(src).protocol) {
     src = 'http://' + src;
   }
   return fetch(src)


### PR DESCRIPTION
Previously had a nasty `://` check, which trips up embedders and makes `data:` url usage not work.