### PR TITLE
Auto go command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1371,14 +1371,6 @@ const _start = () => {
       prompt,
       eval: replEval,
     });
-    r.defineCommand('go', {
-      help: 'Navigate to <url>',
-      action(url) {
-        window.location.href = url;
-        this.clearBufferedCommand();
-        this.displayPrompt();
-      }
-    });
     replHistory(r, path.join(dataPath, '.repl_history'));
     r.on('exit', () => {
       process.exit();

--- a/index.js
+++ b/index.js
@@ -1319,7 +1319,7 @@ const _start = () => {
       let result, err = null, match;
 
       if (/^https?:\/\//.test(cmd)) {
-        window.location.href = url;
+        window.location.href = cmd;
       } else if (/^\s*<(?:\!\-*)?[a-z]/i.test(cmd)) {
         const e = window.document.createElement('div');
         e.innerHTML = cmd;

--- a/index.js
+++ b/index.js
@@ -1318,7 +1318,7 @@ const _start = () => {
 
       let result, err = null, match;
 
-      if (/^https?:\/\//.test(cmd)) {
+      if (/^[a-z]+:\/\//.test(cmd)) {
         window.location.href = cmd;
       } else if (/^\s*<(?:\!\-*)?[a-z]/i.test(cmd)) {
         const e = window.document.createElement('div');

--- a/index.js
+++ b/index.js
@@ -1318,7 +1318,9 @@ const _start = () => {
 
       let result, err = null, match;
 
-      if (/^\s*<(?:\!\-*)?[a-z]/i.test(cmd)) {
+      if (/^https?:\/\//.test(cmd)) {
+        window.location.href = url;
+      } else if (/^\s*<(?:\!\-*)?[a-z]/i.test(cmd)) {
         const e = window.document.createElement('div');
         e.innerHTML = cmd;
         if (e.childNodes.length === 0) {


### PR DESCRIPTION
We've always had a `.go <url>` command.

This replaces that with the ability to simply type the URL in the CLI to open it. That's simpler for users to understand.