### PR TITLE
Revert "Locally track timeouts and intervals in tickAnimationFrame"

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -10,6 +10,3 @@ module.exports.mrDisplaysSymbol = Symbol();
 module.exports.optionsSymbol = Symbol();
 module.exports.pointerLockElementSymbol = Symbol();
 module.exports.prioritySymbol = Symbol();
-module.exports.startTimeSymbol = Symbol();
-module.exports.timeoutSymbol = Symbol();
-module.exports.intervalSymbol = Symbol();


### PR DESCRIPTION
Closes #174.

This reverts commit f061c1bfac5350dc226d87483b93f32fb362cd1d.

Note that the setInterval, setTimeout, and clearTimeout tests are now
failing. However, the audio subsystem no longer crashes.