### PR TITLE
Return null on gl.getUniformLocation not found

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2125,9 +2125,13 @@ NAN_METHOD(WebGLRenderingContext::GetUniformLocation) {
 
   GLint location = glGetUniformLocation(programId, *name);
 
-  Local<Object> locationObject = Nan::New<Object>();
-  locationObject->Set(JS_STR("id"), JS_INT(location));
-  info.GetReturnValue().Set(locationObject);
+  if (location != -1) {
+    Local<Object> locationObject = Nan::New<Object>();
+    locationObject->Set(JS_STR("id"), JS_INT(location));
+    info.GetReturnValue().Set(locationObject);
+  } else {
+    info.GetReturnValue().Set(Nan::Null());
+  }
 }
 
 


### PR DESCRIPTION
`gl.getUniformLocation` is supposed to return `null` on uniform not found: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getUniformLocation.

It was previously returning a `WebGLUniformLocation` bound to GL `-1` because OpenGL returns a `-1` for this case: https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetUniformLocation.xhtml