### PR TITLE
<script> load order unit tests

### DIFF
--- a/tests/unit/data/lol.js
+++ b/tests/unit/data/lol.js
@@ -1,0 +1,1 @@
+window.Lol1 = class Lol1 {};

--- a/tests/unit/data/lol2.js
+++ b/tests/unit/data/lol2.js
@@ -1,0 +1,1 @@
+window.Lol1 = class Lol1 {};

--- a/tests/unit/data/lol2.js
+++ b/tests/unit/data/lol2.js
@@ -1,1 +1,1 @@
-window.Lol1 = class Lol1 {};
+window.Lol2 = class Lol2 {};

--- a/tests/unit/data/scripts.html
+++ b/tests/unit/data/scripts.html
@@ -11,9 +11,10 @@
       window.Lol4 = class Lol4 {};
     </script>
     <script>
-      console.log('got class 1', new window.Lol1());
-      console.log('got class 2', new window.Lol2());
-      console.log('got class 3', new window.Lol3());
+      window.lol1 = new window.Lol1();
+      window.lol2 = new window.Lol2();
+      window.lol3 = new window.Lol3();
+      window.lol4 = new window.Lol4();
     </script>
   </body>
 </html>

--- a/tests/unit/data/scripts.html
+++ b/tests/unit/data/scripts.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <script src="lol.js"></script>
+    <script>
+      window.Lol3 = class Lol3 {};
+    </script>
+  </head>
+  <body>
+    <script src="lol2.js"></script>
+    <script>
+      window.Lol4 = class Lol4 {};
+    </script>
+    <script>
+      console.log('got class 1', new window.Lol1());
+      console.log('got class 2', new window.Lol2());
+      console.log('got class 3', new window.Lol3());
+    </script>
+  </body>
+</html>

--- a/tests/unit/dom/ScriptElement.test.js
+++ b/tests/unit/dom/ScriptElement.test.js
@@ -8,7 +8,10 @@ describe('ScriptElement', () => {
     exokit.load(`${TEST_URL}/scripts.html`)
       .then(o => {
         window = o.window;
-        cb();
+
+        window.onload = () => {
+          cb();
+        };
       });
   });
 

--- a/tests/unit/dom/ScriptElement.test.js
+++ b/tests/unit/dom/ScriptElement.test.js
@@ -1,0 +1,27 @@
+/* global assert, beforeEach, describe, it */
+const exokit = require('../../../index');
+
+describe('ScriptElement', () => {
+  var window;
+
+  beforeEach(cb => {
+    exokit.load(`${TEST_URL}/scripts.html`)
+      .then(o => {
+        window = o.window;
+        cb();
+      });
+  });
+
+  afterEach(() => {
+    window.destroy();
+  });
+
+  describe('<script>', () => {
+    it('runs in order', () => {
+      assert.equal(window.lol1 instanceof window.Lol1, true);
+      assert.equal(window.lol2 instanceof window.Lol2, true);
+      assert.equal(window.lol3 instanceof window.Lol3, true);
+      assert.equal(window.lol4 instanceof window.Lol4, true);
+    });
+  });
+});


### PR DESCRIPTION
Adds run order unit tests for `<script>` tags in running HTML.

- Tests urls
- Test inline scripts

We have `async` and `defer` but we're not testing that here