### PR TITLE
<script async> treatment fixes

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1445,10 +1445,10 @@ class HTMLScriptElement extends HTMLLoadableElement {
       }
       return false;
     };
-    const _run = () => {
+    const _run = async => {
       this.readyState = 'loading';
 
-      if (!this.async) {
+      if (!async) {
         this.ownerDocument[symbols.addRunSymbol](_runInternal);
       } else {
         _runInternal();
@@ -1484,12 +1484,14 @@ class HTMLScriptElement extends HTMLLoadableElement {
     };
     this.on('attribute', (name, value) => {
       if (name === 'src' && value && this.isRunnable() && _isAttached() && this.readyState === null) {
-        _run();
+        const async = this.getAttribute('async');
+        _run(async !== null ? async !== 'false' : false);
       }
     });
     this.on('attached', () => {
       if (this.src && this.isRunnable() && _isAttached() && this.readyState === null) {
-        _run();
+        const async = this.getAttribute('async');
+        _run(async !== null ? async !== 'false' : true);
       }
     });
     this.on('innerHTML', innerHTML => {

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1445,16 +1445,16 @@ class HTMLScriptElement extends HTMLLoadableElement {
       }
       return false;
     };
-    const _run = async => {
+    const _loadRun = async => {
       this.readyState = 'loading';
 
       if (!async) {
-        this.ownerDocument[symbols.addRunSymbol](_runInternal);
+        this.ownerDocument[symbols.addRunSymbol](_loadRunNow);
       } else {
-        _runInternal();
+        _loadRunNow();
       }
     };
-    const _runInternal = () => {
+    const _loadRunNow = () => {
       const resource = this.ownerDocument.resources.addResource();
 
       const url = this.src;
@@ -1485,13 +1485,13 @@ class HTMLScriptElement extends HTMLLoadableElement {
     this.on('attribute', (name, value) => {
       if (name === 'src' && value && this.isRunnable() && _isAttached() && this.readyState === null) {
         const async = this.getAttribute('async');
-        _run(async !== null ? async !== 'false' : false);
+        _loadRun(async !== null ? async !== 'false' : false);
       }
     });
     this.on('attached', () => {
       if (this.src && this.isRunnable() && _isAttached() && this.readyState === null) {
         const async = this.getAttribute('async');
-        _run(async !== null ? async !== 'false' : true);
+        _loadRun(async !== null ? async !== 'false' : true);
       }
     });
     this.on('innerHTML', innerHTML => {

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1502,6 +1502,15 @@ class HTMLScriptElement extends HTMLLoadableElement {
     type = type + '';
     this.setAttribute('type', type);
   }
+  
+  get async() {
+    const async = this.getAttribute('async');
+    return async === null || async !== 'false';
+  }
+  set async(async) {
+    async = async + '';
+    this.setAttribute('async', async);
+  }
 
   get text() {
     let result = '';

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -499,6 +499,14 @@ class Element extends Node {
         this._classList.reset(value);
       }
     });
+    this.on('children', (addedNodes, removedNodes, previousSibling, nextSiblings) => {
+      for (let i = 0; i < addedNodes.length; i++) {
+        addedNodes[i].emit('attached');
+      }
+      for (let i = 0; i < removedNodes.length; i++) {
+        removedNodes[i].emit('removed');
+      }
+    });
   }
 
   get nodeType() {

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1495,7 +1495,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
       }
     });
     this.on('innerHTML', innerHTML => {
-      if (this.isRunnable()) {
+      if (this.isRunnable() && _isAttached() && this.readyState === null) {
         const window = this.ownerDocument.defaultView;
         utils._runJavascript(innerHTML, window, window.location.href, this.location && this.location.line !== null ? this.location.line - 1 : 0, this.location && this.location.col !== null ? this.location.col - 1 : 0);
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1577,12 +1577,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
       }
     }
     if (running) {
-      const asyncAttr = this.attributes.async;
-      if (asyncAttr && asyncAttr.value) {
-        return 'asyncLoad';
-      } else {
-        return 'syncLoad';
-      }
+      return this.async ? 'asyncLoad' : 'syncLoad';
     } else {
       return null;
     }

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1456,7 +1456,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
     };
     const _runInternal = () => {
       const resource = this.ownerDocument.resources.addResource();
-      
+
       const url = this.src;
       return this.ownerDocument.defaultView.fetch(url)
         .then(res => {
@@ -1525,7 +1525,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
     type = type + '';
     this.setAttribute('type', type);
   }
-  
+
   get async() {
     const async = this.getAttribute('async');
     return async === null || async !== 'false';

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1579,7 +1579,12 @@ class HTMLScriptElement extends HTMLLoadableElement {
       }
     }
     if (running) {
-      return this.async ? 'asyncLoad' : 'syncLoad';
+      const async = this.getAttribute('async');
+      if (async !== null) {
+        return async !== 'false' ? 'asyncLoad' : 'syncLoad';
+      } else {
+        return 'syncLoad';
+      }
     } else {
       return null;
     }

--- a/src/Document.js
+++ b/src/Document.js
@@ -99,6 +99,30 @@ function initDocument (document, window) {
   };
   document[symbols.pointerLockElementSymbol] = null;
   document[symbols.fullscreenElementSymbol] = null;
+  
+  let runningEl = false;
+  const runElQueue = [];
+  const _addRun = fn => {
+    (async () => {
+      if (!runningEl) {
+        runningEl = true;
+        
+        try {
+          await fn();
+        } catch(err) {
+          console.warn(err.stack);
+        }
+        
+        runningEl = false;
+        if (runElQueue.length > 0) {
+          _addRun(runElQueue.shift());
+        }
+      } else {
+        runElQueue.push(fn);
+      }
+    })();
+  };
+  document[symbols.addRunSymbol] = _addRun;
 
   if (window.top === window) {
     document.addEventListener('pointerlockchange', () => {

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -13,3 +13,4 @@ module.exports.prioritySymbol = Symbol();
 module.exports.startTimeSymbol = Symbol();
 module.exports.timeoutSymbol = Symbol();
 module.exports.intervalSymbol = Symbol();
+module.exports.addRunSymbol = Symbol();

--- a/tests/unit/data/lol-sync1.js
+++ b/tests/unit/data/lol-sync1.js
@@ -1,0 +1,1 @@
+window.check(1);

--- a/tests/unit/data/lol-sync2.js
+++ b/tests/unit/data/lol-sync2.js
@@ -1,0 +1,1 @@
+window.check(2);

--- a/tests/unit/data/lol-sync3.js
+++ b/tests/unit/data/lol-sync3.js
@@ -1,0 +1,1 @@
+window.check(1);

--- a/tests/unit/dom/ScriptElement.test.js
+++ b/tests/unit/dom/ScriptElement.test.js
@@ -3,11 +3,13 @@ const exokit = require('../../../index');
 
 describe('ScriptElement', () => {
   var window;
+  var document;
 
   beforeEach(cb => {
     exokit.load(`${TEST_URL}/scripts.html`)
       .then(o => {
         window = o.window;
+        document = o.document;
 
         window.onload = () => {
           cb();
@@ -20,11 +22,46 @@ describe('ScriptElement', () => {
   });
 
   describe('<script>', () => {
-    it('runs in order', () => {
+    it('HMTL tags', () => {
       assert.equal(window.lol1 instanceof window.Lol1, true);
       assert.equal(window.lol2 instanceof window.Lol2, true);
       assert.equal(window.lol3 instanceof window.Lol3, true);
       assert.equal(window.lol4 instanceof window.Lol4, true);
+    });
+    
+    it('Insert <script async=false>', cb => {
+      let count = 0;
+      let err = null;
+      window.check = i => {
+        if (i !== count++) {
+          err = err || new Error('failed check ' + i + ' ' + count);
+        }
+        
+        if (count === 2) {
+          cb(err);
+        }
+      };
+      
+      {
+        const script = document.createElement('script');
+        script.async = false;
+        script.src = 'lol-sync0.js';
+        document.body.appendChild(script);
+      }
+
+      {
+        const script = document.createElement('script');                                                
+        script.async = false;
+        script.src = 'lol-sync1.js';
+        document.body.appendChild(script);
+      }
+
+      {
+        const script = document.createElement('script');                                                
+        script.async = false;
+        script.src = 'lol-sync2.js';
+        document.body.appendChild(script);
+      }
     });
   });
 });

--- a/tests/unit/dom/ScriptElement.test.js
+++ b/tests/unit/dom/ScriptElement.test.js
@@ -22,7 +22,7 @@ describe('ScriptElement', () => {
   });
 
   describe('<script>', () => {
-    it('HMTL tags', () => {
+    it('HTML tags', () => {
       assert.equal(window.lol1 instanceof window.Lol1, true);
       assert.equal(window.lol2 instanceof window.Lol2, true);
       assert.equal(window.lol3 instanceof window.Lol3, true);

--- a/tests/unit/dom/ScriptElement.test.js
+++ b/tests/unit/dom/ScriptElement.test.js
@@ -33,9 +33,11 @@ describe('ScriptElement', () => {
       let count = 0;
       let err = null;
       window.check = i => {
-        if (i !== count++) {
+        if (i !== count) {
           err = err || new Error('failed check ' + i + ' ' + count);
         }
+        
+        count++;
         
         if (count === 2) {
           cb(err);


### PR DESCRIPTION
Previously we were not honoring the case of programmatic `document.createElement('script').async = false` followed by attachment.

In that case the script would load, but the correct behavior is to stack the scripts and execute them serially as they are attached to the `document`.

- Implement this behavior
- Add tests
- Add `script.async` accessor support