### PR TITLE
WebGL2 uniform block methods

### DIFF
--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -135,6 +135,7 @@ public:
   static NAN_METHOD(LinkProgram);
   static NAN_METHOD(GetProgramParameter);
   static NAN_METHOD(GetUniformLocation);
+  static NAN_METHOD(GetUniformBlockIndex);
   static NAN_METHOD(ClearColor);
   static NAN_METHOD(ClearDepth);
   static NAN_METHOD(Disable);

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -136,6 +136,7 @@ public:
   static NAN_METHOD(GetProgramParameter);
   static NAN_METHOD(GetUniformLocation);
   static NAN_METHOD(GetUniformBlockIndex);
+  static NAN_METHOD(UniformBlockBinding);
   static NAN_METHOD(ClearColor);
   static NAN_METHOD(ClearDepth);
   static NAN_METHOD(Disable);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -675,6 +675,7 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(proto, "linkProgram", glCallWrap<LinkProgram>);
   Nan::SetMethod(proto, "getProgramParameter", glCallWrap<GetProgramParameter>);
   Nan::SetMethod(proto, "getUniformLocation", glCallWrap<GetUniformLocation>);
+  Nan::SetMethod(proto, "getUniformBlockIndex", glCallWrap<GetUniformBlockIndex>);
   Nan::SetMethod(proto, "getUniform", glCallWrap<GetUniform>);
   Nan::SetMethod(proto, "clearColor", glCallWrap<ClearColor>);
   Nan::SetMethod(proto, "clearDepth", glCallWrap<ClearDepth>);
@@ -2134,6 +2135,14 @@ NAN_METHOD(WebGLRenderingContext::GetUniformLocation) {
   }
 }
 
+NAN_METHOD(WebGLRenderingContext::GetUniformBlockIndex) {
+  GLint programId = info[0]->ToObject()->Get(JS_STR("id"))->Int32Value();
+  v8::String::Utf8Value uniformBlockName(info[1]);
+
+  GLint blockIndex = glGetUniformBlockIndex(programId, *uniformBlockName);
+
+  info.GetReturnValue().Set(JS_INT(blockIndex));
+}
 
 NAN_METHOD(WebGLRenderingContext::ClearColor) {
   float red = (float)info[0]->NumberValue();

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -676,6 +676,7 @@ Handle<Object> WebGLRenderingContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(proto, "getProgramParameter", glCallWrap<GetProgramParameter>);
   Nan::SetMethod(proto, "getUniformLocation", glCallWrap<GetUniformLocation>);
   Nan::SetMethod(proto, "getUniformBlockIndex", glCallWrap<GetUniformBlockIndex>);
+  Nan::SetMethod(proto, "uniformBlockBinding", glCallWrap<UniformBlockBinding>);
   Nan::SetMethod(proto, "getUniform", glCallWrap<GetUniform>);
   Nan::SetMethod(proto, "clearColor", glCallWrap<ClearColor>);
   Nan::SetMethod(proto, "clearDepth", glCallWrap<ClearDepth>);
@@ -2142,6 +2143,14 @@ NAN_METHOD(WebGLRenderingContext::GetUniformBlockIndex) {
   GLint blockIndex = glGetUniformBlockIndex(programId, *uniformBlockName);
 
   info.GetReturnValue().Set(JS_INT(blockIndex));
+}
+
+NAN_METHOD(WebGLRenderingContext::UniformBlockBinding) {
+  GLint programId = info[0]->ToObject()->Get(JS_STR("id"))->Int32Value();
+  GLuint uniformBlockIndex = info[1]->Uint32Value();
+  GLuint uniformBlockBinding = info[2]->Uint32Value();
+
+  glUniformBlockBinding(programId, uniformBlockIndex, uniformBlockBinding);
 }
 
 NAN_METHOD(WebGLRenderingContext::ClearColor) {


### PR DESCRIPTION
- [getUniformBlockIndex](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/getUniformBlockIndex)
- [uniformBlockBinding](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/uniformBlockBinding)