### PR TITLE
Bugfix WebXR/WebVR render metrics

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,8 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
       gl.setDefaultFramebuffer(msFramebuffer);
 
       gl.resize = (width, height) => {
+        nativeWindow.setCurrentWindowContext(windowHandle);
+
         nativeWindow.resizeRenderTarget(gl, width, height, framebuffer, colorTexture, depthStencilTexture, msFramebuffer, msColorTexture, msDepthStencilTexture);
       };
 
@@ -152,7 +154,9 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
         },
       });
     } else {
-      gl.resize = (width, height) => {    
+      gl.resize = (width, height) => {
+        nativeWindow.setCurrentWindowContext(windowHandle);
+
         nativeWindow.resizeRenderTarget(gl, width, height, sharedFramebuffer, sharedColorTexture, sharedDepthStencilTexture, sharedMsFramebuffer, sharedMsColorTexture, sharedMsDepthStencilTexture);
       };
     }
@@ -298,7 +302,8 @@ nativeVr.requestPresent = function(layers) {
       }
       const window = canvas.ownerDocument.defaultView;
 
-      nativeWindow.setCurrentWindowContext(context.getWindowHandle());
+      const windowHandle = context.getWindowHandle();
+      nativeWindow.setCurrentWindowContext(windowHandle);
 
       const vrContext = vrPresentState.vrContext || nativeVr.getContext();
       const system = vrPresentState.system || nativeVr.VR_Init(nativeVr.EVRApplicationType.Scene);
@@ -332,6 +337,8 @@ nativeVr.requestPresent = function(layers) {
 
       const _attribute = (name, value) => {
         if (name === 'width' || name === 'height') {
+          nativeWindow.setCurrentWindowContext(windowHandle);
+          
           nativeWindow.resizeRenderTarget(context, canvas.width, canvas.height, fbo, tex, depthStencilTex, msFbo, msTex, msDepthStencilTex);
         }
       };

--- a/index.js
+++ b/index.js
@@ -375,7 +375,7 @@ nativeVr.exitPresent = function() {
     const context = vrPresentState.glContext;
     nativeWindow.setCurrentWindowContext(context.getWindowHandle());
     context.setDefaultFramebuffer(0);
-    
+
     for (let i = 0; i < vrPresentState.cleanups.length; i++) {
       vrPresentState.cleanups[i]();
     }

--- a/index.js
+++ b/index.js
@@ -331,6 +331,16 @@ nativeVr.requestPresent = function(layers) {
 
       vrPresentState.lmContext = lmContext;
 
+      const _attribute = (name, value) => {
+        if (name === 'width' || name === 'height') {
+          nativeWindow.resizeRenderTarget(context, canvas.width, canvas.height, fbo, tex, depthStencilTex, msFbo, msTex, msDepthStencilTex);
+        }
+      };
+      canvas.on('attribute', _attribute);
+      cleanups.push(() => {
+        canvas.removeListener('attribute', _attribute);
+      });
+
       window.top.updateVrFrame({
         renderWidth,
         renderHeight,

--- a/index.js
+++ b/index.js
@@ -160,6 +160,16 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
         },
       });
     }
+    Object.defineProperty(gl, 'drawingBufferWidth', {
+      get() {
+        return canvas.width;
+      },
+    });
+    Object.defineProperty(gl, 'drawingBufferHeight', {
+      get() {
+        return canvas.height;
+      },
+    });
 
     const ondomchange = () => {
       process.nextTick(() => { // show/hide synchronously emits events

--- a/index.js
+++ b/index.js
@@ -135,17 +135,9 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
 
       gl.setDefaultFramebuffer(msFramebuffer);
 
-      const _attribute = (name, value) => {
-        if (name === 'width' || name === 'height') {
-          nativeWindow.setCurrentWindowContext(windowHandle);
-
-          nativeWindow.resizeRenderTarget(gl, canvas.width, canvas.height, framebuffer, colorTexture, depthStencilTexture, msFramebuffer, msColorTexture, msDepthStencilTexture);
-        }
+      gl.resize = (width, height) => {
+        nativeWindow.resizeRenderTarget(gl, width, height, framebuffer, colorTexture, depthStencilTexture, msFramebuffer, msColorTexture, msDepthStencilTexture);
       };
-      canvas.on('attribute', _attribute);
-      cleanups.push(() => {
-        canvas.removeListener('attribute', _attribute);
-      });
 
       document._emit('framebuffer', {
         framebuffer,
@@ -159,6 +151,11 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
           nativeWindow.blitFrameBuffer(gl, msFramebuffer, framebuffer, canvas.width, canvas.height, canvas.width, canvas.height, false, true, true);
         },
       });
+    } else {
+      gl.resize = (width, height) => {
+        console.log('resize canvas', width, height, sharedFramebuffer);      
+        nativeWindow.resizeRenderTarget(gl, width, height, sharedFramebuffer, sharedColorTexture, sharedDepthStencilTexture, sharedMsFramebuffer, sharedMsColorTexture, sharedMsDepthStencilTexture);
+      };
     }
     Object.defineProperty(gl, 'drawingBufferWidth', {
       get() {

--- a/index.js
+++ b/index.js
@@ -728,12 +728,12 @@ const _bindWindow = (window, newWindowCb) => {
 
         if (nativeWindow.isVisible(windowHandle) || vrPresentState.glContext === context || mlGlContext === context) {
           if (vrPresentState.glContext === context && vrPresentState.hasPose) {
-            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, vrPresentState.fbo, renderWidth * 2, renderHeight, renderWidth * 2, renderHeight, true, false, false);
+            nativeWindow.blitFrameBuffer(context, vrPresentState.msFbo, vrPresentState.fbo, vrPresentState.glContext.canvas.width, vrPresentState.glContext.canvas.height, vrPresentState.glContext.canvas.width, vrPresentState.glContext.canvas.height, true, false, false);
 
             vrPresentState.compositor.Submit(context, vrPresentState.tex);
             vrPresentState.hasPose = false;
 
-            nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, renderWidth * (args.blit ? 1 : 2), renderHeight, window.innerWidth, window.innerHeight, true, false, false);
+            nativeWindow.blitFrameBuffer(context, vrPresentState.fbo, 0, vrPresentState.glContext.canvas.width * (args.blit ? 0.5 : 1), vrPresentState.glContext.canvas.height, window.innerWidth, window.innerHeight, true, false, false);
           } else if (mlGlContext === context && mlHasPose) {
             mlContext.SubmitFrame(mlFbo, window.innerWidth, window.innerHeight);
             mlHasPose = false;

--- a/index.js
+++ b/index.js
@@ -273,6 +273,7 @@ const vrPresentState = {
   msTex: null,
   fbo: null,
   tex: null,
+  cleanups: null,
   hasPose: false,
   lmContext: null,
 };
@@ -304,6 +305,8 @@ nativeVr.requestPresent = function(layers) {
       renderWidth = halfWidth;
       renderHeight = height;
 
+      const cleanups = [];
+
       const [fbo, tex, depthStencilTex, msFbo, msTex, msDepthStencilTex] = nativeWindow.createRenderTarget(context, width, height, 0, 0, 0, 0);
 
       context.setDefaultFramebuffer(msFbo);
@@ -317,6 +320,7 @@ nativeVr.requestPresent = function(layers) {
       vrPresentState.msTex = msTex;
       vrPresentState.fbo = fbo;
       vrPresentState.tex = tex;
+      vrPresentState.cleanups = cleanups;
 
       vrPresentState.lmContext = lmContext;
 
@@ -355,6 +359,10 @@ nativeVr.exitPresent = function() {
     const context = vrPresentState.glContext;
     nativeWindow.setCurrentWindowContext(context.getWindowHandle());
     context.setDefaultFramebuffer(0);
+    
+    for (let i = 0; i < vrPresentState.cleanups.length; i++) {
+      vrPresentState.cleanups[i]();
+    }
 
     vrPresentState.isPresenting = false;
     vrPresentState.system = null;
@@ -364,6 +372,7 @@ nativeVr.exitPresent = function() {
     vrPresentState.msTex = null;
     vrPresentState.fbo = null;
     vrPresentState.tex = null;
+    vrPresentState.cleanups = null;
   }
 
   return Promise.resolve();

--- a/index.js
+++ b/index.js
@@ -152,8 +152,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
         },
       });
     } else {
-      gl.resize = (width, height) => {
-        console.log('resize canvas', width, height, sharedFramebuffer);      
+      gl.resize = (width, height) => {    
         nativeWindow.resizeRenderTarget(gl, width, height, sharedFramebuffer, sharedColorTexture, sharedDepthStencilTexture, sharedMsFramebuffer, sharedMsColorTexture, sharedMsDepthStencilTexture);
       };
     }

--- a/src/XR.js
+++ b/src/XR.js
@@ -141,6 +141,17 @@ class XRSession extends EventTarget {
       this.depthFar = depthFar;
     }
     if (renderWidth !== undefined && renderHeight !== undefined) {
+      if (this.baseLayer) {
+        const {context} = this.baseLayer;
+
+        if (context.drawingBufferWidth !== renderWidth * 2) {
+          context.canvas.width = renderWidth * 2;
+        }
+        if (context.drawingBufferHeight !== renderHeight) {
+          context.canvas.height = renderHeight;
+        }
+      }
+
       for (let i = 0; i < this._frame.views.length; i++) {
         this._frame.views[i]._viewport.set(i * renderWidth, 0, renderWidth, renderHeight);
       }


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/283.

This fixes several issues where the WebVR/WebXR/main canvas sizing was out of sync.

- The headset resolution previously assumed the base canvas context would be resized to accommodate the headset. This is _usually_ not always the case in different engines.
- Headset framebuffer was not resized on canvas framebuffer changes.