### PR TITLE
ErrorEvent spec conformance

### DIFF
--- a/core.js
+++ b/core.js
@@ -1593,9 +1593,11 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         })
         .catch(err => {
           loading = false;
-          window._emit('error', {
-            error: err,
-          });
+
+          const e = new Event('error', {target: this});
+          e.message = err.message;
+          e.stack = err.stack;
+          this.dispatchEvent(e);
         });
       loading = true;
     }

--- a/core.js
+++ b/core.js
@@ -49,8 +49,7 @@ const {_parseDocument, _parseDocumentAst, Document, DocumentFragment, DocumentTy
        DOMImplementation, initDocument} = require('./src/Document');
 const DOM = require('./src/DOM');
 const {DOMRect, Node, NodeList} = require('./src/DOM');
-const {CustomEvent, DragEvent, Event, EventTarget, KeyboardEvent, MessageEvent, MouseEvent,
-       WheelEvent} = require('./src/Event');
+const {CustomEvent, DragEvent, ErrorEvent, Event, EventTarget, KeyboardEvent, MessageEvent, MouseEvent, WheelEvent} = require('./src/Event');
 const {History} = require('./src/History');
 const {Location} = require('./src/Location');
 const {XMLHttpRequest} = require('./src/Network');
@@ -1594,7 +1593,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         .catch(err => {
           loading = false;
 
-          const e = new Event('error', {target: this});
+          const e = new ErrorEvent('error', {target: this});
           e.message = err.message;
           e.stack = err.stack;
           this.dispatchEvent(e);

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -9,7 +9,7 @@ const util = require('util');
 
 const bindings = require('./bindings');
 const {defaultCanvasSize} = require('./constants');
-const {Event, EventTarget, MouseEvent} = require('./Event');
+const {Event, EventTarget, MouseEvent, ErrorEvent} = require('./Event');
 const GlobalContext = require('./GlobalContext');
 const symbols = require('./symbols');
 const urls = require('./urls').urls;
@@ -1322,7 +1322,7 @@ class HTMLStyleElement extends HTMLLoadableElement {
           this.dispatchEvent(new Event('load', {target: this}));
         })
         .catch(err => {
-          const e = new Event('error', {target: this});
+          const e = new ErrorEvent('error', {target: this});
           e.message = err.message;
           e.stack = err.stack;
           this.dispatchEvent(e);
@@ -1386,7 +1386,7 @@ class HTMLLinkElement extends HTMLLoadableElement {
             this.dispatchEvent(new Event('load', {target: this}));
           })
           .catch(err => {
-            const e = new Event('error', {target: this});
+            const e = new ErrorEvent('error', {target: this});
             e.message = err.message;
             e.stack = err.stack;
             this.dispatchEvent(e);
@@ -1482,7 +1482,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
         .catch(err => {
           this.readyState = 'complete';
 
-          const e = new Event('error', {target: this});
+          const e = new ErrorEvent('error', {target: this});
           e.message = err.message;
           e.stack = err.stack;
           this.dispatchEvent(e);
@@ -2105,7 +2105,7 @@ class HTMLImageElement extends HTMLSrcableElement {
           .catch(err => {
             console.warn('failed to load image:', src);
 
-            const e = new Event('error', {target: this});
+            const e = new ErrorEvent('error', {target: this});
             e.message = err.message;
             e.stack = err.stack;
             this.dispatchEvent(e);
@@ -2203,7 +2203,7 @@ class HTMLAudioElement extends HTMLMediaElement {
           .catch(err => {
             console.warn('failed to load audio:', src);
 
-            const e = new Event('error', {target: this});
+            const e = new ErrorEvent('error', {target: this});
             e.message = err.message;
             e.stack = err.stack;
             this.dispatchEvent(e);

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1322,7 +1322,10 @@ class HTMLStyleElement extends HTMLLoadableElement {
           this.dispatchEvent(new Event('load', {target: this}));
         })
         .catch(err => {
-          this.dispatchEvent(new Event('error', {target: this}));
+          const e = new Event('error', {target: this});
+          e.message = err.message;
+          e.stack = err.stack;
+          this.dispatchEvent(e);
         });
     });
   }
@@ -1383,7 +1386,10 @@ class HTMLLinkElement extends HTMLLoadableElement {
             this.dispatchEvent(new Event('load', {target: this}));
           })
           .catch(err => {
-            this.dispatchEvent(new Event('error', {target: this}));
+            const e = new Event('error', {target: this});
+            e.message = err.message;
+            e.stack = err.stack;
+            this.dispatchEvent(e);
           });
       }
     });
@@ -1476,7 +1482,10 @@ class HTMLScriptElement extends HTMLLoadableElement {
         .catch(err => {
           this.readyState = 'complete';
 
-          this.dispatchEvent(new Event('error', {target: this}));
+          const e = new Event('error', {target: this});
+          e.message = err.message;
+          e.stack = err.stack;
+          this.dispatchEvent(e);
         })
         .finally(() => {
           resource.setProgress(1);
@@ -2095,7 +2104,11 @@ class HTMLImageElement extends HTMLSrcableElement {
           })
           .catch(err => {
             console.warn('failed to load image:', src);
-            this.dispatchEvent(new Event('error', {target: this}));
+
+            const e = new Event('error', {target: this});
+            e.message = err.message;
+            e.stack = err.stack;
+            this.dispatchEvent(e);
           })
           .finally(() => {
             resource.setProgress(1);
@@ -2189,7 +2202,11 @@ class HTMLAudioElement extends HTMLMediaElement {
           })
           .catch(err => {
             console.warn('failed to load audio:', src);
-            this.dispatchEvent(new Event('error', {target: this}));
+
+            const e = new Event('error', {target: this});
+            e.message = err.message;
+            e.stack = err.stack;
+            this.dispatchEvent(e);
           })
           .finally(() => {
             resource.setProgress(1);

--- a/src/Event.js
+++ b/src/Event.js
@@ -233,6 +233,13 @@ class MessageEvent extends Event {
 }
 module.exports.MessageEvent = MessageEvent;
 
+class ErrorEvent extends Event {
+  constructor(type, init = {}) {
+    super(type, init);
+  }
+}
+module.exports.ErrorEvent = ErrorEvent;
+
 class CustomEvent extends Event {
   constructor(type, init = {}) {
     super(type, init);

--- a/src/Event.js
+++ b/src/Event.js
@@ -84,7 +84,7 @@ class Event {
     this.cancelable = cancelable;
   }
 }
-module.exports.Event= Event;
+module.exports.Event = Event;
 
 class KeyboardEvent extends Event {
   constructor(type, init = {}) {


### PR DESCRIPTION
Previously we were emitting generic `Error` with no `message` or `stack` which made it hard to pinpoint the source of error emits in logging.

This adds `.message` and `.stack` to error emits from the DOM dispatch.

Additionally we replace the generic Event with an [ErrorEvent as in the specs](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent).

This should help in debugging site throws.