### PR TITLE
Add auto-exit when all windows are closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,6 +215,10 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
       canvas.ownerDocument.removeListener('domchange', ondomchange);
 
       contexts.splice(contexts.indexOf(gl), 1);
+
+      if (!contexts.some(context => !nativeWindow.isVisible(context.getWindowHandle()))) { // no more windows
+        process.exit();
+      }
     });
 
     gl.destroy = (destroy => function() {

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
 
       contexts.splice(contexts.indexOf(gl), 1);
 
-      if (!contexts.some(context => !nativeWindow.isVisible(context.getWindowHandle()))) { // no more windows
+      if (!contexts.some(context => nativeWindow.isVisible(context.getWindowHandle()))) { // no more windows
         process.exit();
       }
     });


### PR DESCRIPTION
Previously we would hang around the `node` process even after all windows (`<canvas>` elements) were closed by the user.

This made some amount of sense (the site it still technically running) but users weren't expecting this -- they were expecting the app to close. This was worse on OSX where the still-open app in the background would prevent subsequent opening of the app until a force-kill.

This PR makes it so that when you close the last visible window the process exits.