### PR TITLE
Append to logs instead of replacing logfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -1518,7 +1518,9 @@ if (require.main === module) {
   });
   if (args.log) {
     const RedirectOutput = require('redirect-output').default;
-    new RedirectOutput().write(path.join(dataPath, 'log.txt'));
+    new RedirectOutput({
+      flags: 'a',
+    }).write(path.join(dataPath, 'log.txt'));
   }
 
   const _logStack = err => {


### PR DESCRIPTION
We log to `$HOME/.exokit/log.txt` with the `-l` flag. This changes the mode for that file write to be `append` instead of `write and replace`.

This should help with logs being overwritten in the "send me a log file" scenario.