### PR TITLE
Throttle vrdisplayactivate

### DIFF
--- a/index.js
+++ b/index.js
@@ -855,7 +855,6 @@ const _bindWindow = (window, newWindowCb) => {
   const frameData = new window.VRFrameData();
   const stageParameters = new window.VRStageParameters();
   let timeout = null;
-  let numFrames = 0;
   let numDirtyFrames = 0;
   const dirtyFrameContexts = [];
   const _checkDirtyFrameTimeout = () => {
@@ -1261,21 +1260,6 @@ const _bindWindow = (window, newWindowCb) => {
     if (args.frame || args.minimalFrame) {
       console.log('-'.repeat(80) + 'start frame');
     }
-    if (window.document.readyState === 'complete' && (numFrames % FPS) === 0) {
-      const displays = window.navigator.getVRDisplaysSync();
-      const presentingDisplay = displays.find(display => display.isPresenting);
-      if (presentingDisplay) {
-        const e = new window.Event('vrdisplaycheck');
-        e.display = presentingDisplay;
-        window.dispatchEvent(e);
-      } else {
-        for (let i = 0; i < displays.length; i++) {
-          const e = new window.Event('vrdisplayactivate');
-          e.display = displays[i];
-          window.dispatchEvent(e);
-        }
-      }
-    }
     window.tickAnimationFrame();
     if (args.performance) {
       const now = Date.now();
@@ -1299,7 +1283,6 @@ const _bindWindow = (window, newWindowCb) => {
     if (args.frame || args.minimalFrame) {
       console.log('-'.repeat(80) + 'end frame');
     }
-    numFrames++;
 
     // wait for next frame
     const now = Date.now();

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1575,7 +1575,9 @@ class HTMLScriptElement extends HTMLLoadableElement {
         this.dispatchEvent(e);
       })
       .finally(() => {
-        resource.setProgress(1);
+        setImmediate(() => {
+          resource.setProgress(1);
+        });
       });
   }
   
@@ -1588,7 +1590,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
 
     const resource = this.ownerDocument.resources.addResource();
 
-    process.nextTick(() => {
+    setImmediate(() => {
       this.dispatchEvent(new Event('load', {target: this}));
 
       resource.setProgress(1);
@@ -1802,7 +1804,9 @@ class HTMLIFrameElement extends HTMLSrcableElement {
             this.dispatchEvent(new Event('load', {target: this}));
           })
           .finally(() => {
-            resource.setProgress(1);
+            setImmediate(() => {
+              resource.setProgress(1);
+            });
           });
       } else if (name === 'hidden') {
         if (this.contentDocument) {
@@ -2117,7 +2121,9 @@ class HTMLImageElement extends HTMLSrcableElement {
             this.dispatchEvent(e);
           })
           .finally(() => {
-            resource.setProgress(1);
+            setImmediate(() => {
+              resource.setProgress(1);
+            });
           });
       }
     });
@@ -2215,7 +2221,9 @@ class HTMLAudioElement extends HTMLMediaElement {
             this.dispatchEvent(e);
           })
           .finally(() => {
-            resource.setProgress(1);
+            setImmediate(() => {
+              resource.setProgress(1);
+            });
           });
       }
     });
@@ -2268,7 +2276,7 @@ class HTMLVideoElement extends HTMLMediaElement {
 
         const resource = this.ownerDocument.resources.addResource();
 
-        process.nextTick(() => {
+        setImmediate(() => {
           this.dispatchEvent(new Event('canplay', {target: this}));
           this.dispatchEvent(new Event('canplaythrough', {target: this}));
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -24,7 +24,6 @@ const _promiseSerial = async promiseFns => {
   }
 };
 const _loadPromise = el => new Promise((accept, reject) => {
-  console.log('load promise', el.tagName);
   const load = () => {
     _cleanup();
     accept();

--- a/src/Document.js
+++ b/src/Document.js
@@ -176,6 +176,33 @@ function initDocument (document, window) {
 
       document.dispatchEvent(new Event('load', {target: document}));
       window.dispatchEvent(new Event('load', {target: window}));
+
+      const _emitDisplays = () => {
+        const displays = window.navigator.getVRDisplaysSync();
+        const presentingDisplay = displays.find(display => display.isPresenting);
+        if (presentingDisplay) {
+          const e = new window.Event('vrdisplayactivate');
+          e.display = presentingDisplay;
+          window.dispatchEvent(e);
+        } else {
+          for (let i = 0; i < displays.length; i++) {
+            const e = new window.Event('vrdisplayactivate');
+            e.display = displays[i];
+            window.dispatchEvent(e);
+          }
+        }
+      };
+      if (document.resources.resources.length === 0) {
+        _emitDisplays();
+      } else {
+        const _update = () => {
+          if (document.resources.resources.length === 0) {
+            _emitDisplays();
+            document.resources.removeEventListener('update', _update);
+          }
+        };
+        document.resources.addEventListener('update', _update);
+      }
     } else {
       try {
         await GlobalContext._runHtml(document, window);

--- a/src/XR.js
+++ b/src/XR.js
@@ -23,7 +23,7 @@ class XR extends EventEmitter {
   requestDevice(name = 'VR') {
     if (name === 'VR' && GlobalContext.nativeVr.VR_IsHmdPresent()) {
       return Promise.resolve(_getXrDisplay(this._window));
-    } else if (name === 'AR' && GlobalContext.nativeMl.IsPresent()) {
+    } else if (name === 'AR' && GlobalContext.nativeMl && GlobalContext.nativeMl.IsPresent()) {
       return Promise.resolve(_getXmDisplay(this._window));
     } else {
       return Promise.resolve(null);


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/305.

Previously `vrdisplayactivate` was an ongoing periodic emit.

This makes it so that `vrdisplayactivate` is fired when:

- `window.onload` has happened
- there are no more pending resource loads happening

This hueristic seems to work well for engines. It also actually decreases latency of entering XR and decreases performance overhead since we're no longer emitting these pointless events in the render loop.