### PR TITLE
Bugfix window resize events

### DIFF
--- a/index.js
+++ b/index.js
@@ -557,7 +557,7 @@ nativeWindow.setEventHandler((type, data) => {
 
         window.innerWidth = innerWidth;
         window.innerHeight = innerHeight;
-        canvas.dispatchEvent(new window.Event('resize'));
+        window.dispatchEvent(new window.Event('resize'));
         break;
       }
       case 'keydown': {


### PR DESCRIPTION
They were emitted on `canvas` but should be emitted on the `window`.