### PR TITLE
Vrdisplayactivate twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "lint": "eslint core.js index.js native-bindings.js src tests",
     "rebuild": "shx rm -rf node_modules && npm cache clean --force && npm install",
     "start": "node .",
-    "test:ci": "TEST_ENV=ci npm run test:command -- --exit",
-    "test:command": "mocha tests/unit/__setup.test.js tests/unit/*.test.js tests/unit/**/*.test.js",
+    "test:ci": "TEST_ENV=ci npm run test:command -- --full-trace --exit",
+    "test:command": "mocha --full-trace tests/unit/__setup.test.js tests/unit/*.test.js tests/unit/**/*.test.js",
     "test:watch": "npm run test:command -- --watch",
     "serve": "serve examples"
   },

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1782,18 +1782,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
               contentDocument.on('framebuffer', framebuffer => {
                 this._emit('framebuffer', framebuffer);
               });
-              const _vrdisplaycheck = e => {
-                if (contentDocument.readyState === 'complete') {
-                  const newEvent = new Event('vrdisplayactivate');
-                  newEvent.display = e.display;
-                  contentWindow.dispatchEvent(newEvent);
-                }
-              };
-              parentWindow.top.on('vrdisplaycheck', _vrdisplaycheck);
               contentWindow.on('destroy', e => {
                 parentWindow.emit('destroy', e);
-
-                parentWindow.top.removeListener('vrdisplaycheck', _vrdisplaycheck);
               });
 
               this.dispatchEvent(new Event('load', {target: this}));

--- a/src/Document.js
+++ b/src/Document.js
@@ -206,7 +206,9 @@ function initDocument (document, window) {
         if (n === 0) {
           fn();
         } else {
-          window.requestAnimationFrame(fn, n - 1);
+          window.requestAnimationFrame(() => {
+            _delayFrames(fn, n - 1);
+          });
         }
       };
       if (document.resources.resources.length === 0) {

--- a/src/Document.js
+++ b/src/Document.js
@@ -183,7 +183,7 @@ function initDocument (document, window) {
           if (!_tryEmitDisplay()) {
             _delayFrames(() => {
               _tryEmitDisplay();
-            }, 100);
+            }, 1);
           }
         };
         const _tryEmitDisplay = () => {

--- a/src/Document.js
+++ b/src/Document.js
@@ -178,32 +178,29 @@ function initDocument (document, window) {
       window.dispatchEvent(new Event('load', {target: window}));
 
       const _initDisplays = () => {
+        if (!_tryEmitDisplay()) {
+          _delayFrames(() => {
+            _tryEmitDisplay();
+          }, 100);
+        }
+      };
+      const _tryEmitDisplay = () => {
         const displays = window.navigator.getVRDisplaysSync();
         const presentingDisplay = displays.find(display => display.isPresenting);
         if (presentingDisplay) {
-          _emitOneDisplay(presentingDisplay);
+          if (presentingDisplay.constructor.name === 'FakeVRDisplay') {
+            _emitOneDisplay(presentingDisplay);
+          }
+          return true;
         } else {
-          _emitAllDisplays(displays);
-          
-          _delayFrames(() => {
-            const displays = window.navigator.getVRDisplaysSync();
-            if (!displays.find(display => display.isPresenting)) {
-              _emitAllDisplays(displays);
-            }
-          }, 100);
+          _emitOneDisplay(displays[0]);
+          return false;
         }
       };
       const _emitOneDisplay = display => {
         const e = new window.Event('vrdisplayactivate');
         e.display = display;
         window.dispatchEvent(e);
-      };
-      const _emitAllDisplays = displays => {
-        for (let i = 0; i < displays.length; i++) {
-          const e = new window.Event('vrdisplayactivate');
-          e.display = displays[i];
-          window.dispatchEvent(e);
-        }
       };
       const _delayFrames = (fn, n = 1) => {
         if (n === 0) {

--- a/src/Document.js
+++ b/src/Document.js
@@ -99,19 +99,19 @@ function initDocument (document, window) {
   };
   document[symbols.pointerLockElementSymbol] = null;
   document[symbols.fullscreenElementSymbol] = null;
-  
+
   const runElQueue = [];
   const _addRun = fn => {
     (async () => {
       if (!document[symbols.runningSymbol]) {
         document[symbols.runningSymbol] = true;
-        
+
         try {
           await fn();
         } catch(err) {
           console.warn(err.stack);
         }
-        
+
         document[symbols.runningSymbol] = false;
         if (runElQueue.length > 0) {
           _addRun(runElQueue.shift());

--- a/tests/unit/Document.test.js
+++ b/tests/unit/Document.test.js
@@ -13,6 +13,8 @@ describe('_parseDocument', () => {
     // Stub fetch for script tag.
     window.fetch = () => Promise.resolve(new Response(''));
     const document = GlobalContext._parseDocument(dummyHtml, window);
+    window.document = document;
+    window.navigator.getVRDisplaysSync = () => [];
     assert.ok(document);
     assert.ok(document.head);
     assert.ok(document.body);

--- a/tests/unit/MutationObserver.test.js
+++ b/tests/unit/MutationObserver.test.js
@@ -1,13 +1,24 @@
 /* global assert, beforeEach, describe, it */
-const helpers = require('./helpers');
+const exokit = require('../../index');
 
 describe('MutationObserver', () => {
   var childEl;
   var el;
+  var window;
+  var document;
+  var MutationObserver;
 
-  const window = helpers.createWindow();
-  const document = window.document;
-  const MutationObserver = window.MutationObserver;
+  before(() => {
+    const o = exokit();
+    window = o.window;
+    window.navigator.getVRDisplaysSync = () => [];
+    document = o.document;
+    MutationObserver = window.MutationObserver;
+  });
+  
+  after(() => {
+    window.destroy();
+  });
 
   beforeEach(() => {
     el = document.createElement('div');

--- a/tests/unit/audio.test.js
+++ b/tests/unit/audio.test.js
@@ -1,6 +1,7 @@
 /* global assert, it */
 const fs = require('fs');
 const path = require('path');
+const exokit = require('../../index');
 const helpers = require('./helpers');
 
 let testBuffer = fs.readFileSync(path.resolve(__dirname, './data/test.ogg'));
@@ -8,9 +9,19 @@ testBuffer = new Uint8Array(testBuffer).buffer;
 
 helpers.describeSkipCI('audio', () => {
   var window;
+  
+  beforeEach(() => {
+    const o = exokit();
+    window = o.window;
+    
+    window.navigator.getVRDisplaysSync = () => [];
+  });
+  
+  afterEach(() => {
+    window.destroy();
+  });
 
   it('creates audio context', done => {
-    window = helpers.createWindow();
     let context = new window.AudioContext();
     context.decodeAudioData(testBuffer, audioBuffer => {
       assert.ok(audioBuffer);
@@ -19,7 +30,6 @@ helpers.describeSkipCI('audio', () => {
   });
 
   it('handles invalid audio context data', done => {
-    window = helpers.createWindow();
     let context = new window.AudioContext();
     context.decodeAudioData('foo').catch(() => {
       done();
@@ -28,7 +38,6 @@ helpers.describeSkipCI('audio', () => {
 
 
   it('catches user callback error', done => {
-    window = helpers.createWindow();
     let context = new window.AudioContext();
     context.decodeAudioData(testBuffer, () => {
       done();

--- a/tests/unit/dom/Element.test.js
+++ b/tests/unit/dom/Element.test.js
@@ -5,7 +5,7 @@ describe('Element', () => {
   var window;
   var document;
   var el;
-  
+
   beforeEach(() => {
     const o = exokit();
     window = o.window;
@@ -13,7 +13,7 @@ describe('Element', () => {
     document = o.document;
     el = document.createElement('a');
   });
-  
+
   afterEach(() => {
     window.destroy();
   });

--- a/tests/unit/dom/Element.test.js
+++ b/tests/unit/dom/Element.test.js
@@ -2,12 +2,20 @@
 const exokit = require('../../../index');
 
 describe('Element', () => {
+  var window;
   var document;
   var el;
-
+  
   beforeEach(() => {
-    document = exokit().document;
+    const o = exokit();
+    window = o.window;
+    window.navigator.getVRDisplaysSync = () => [];
+    document = o.document;
     el = document.createElement('a');
+  });
+  
+  afterEach(() => {
+    window.destroy();
   });
 
   describe('cloneNode', () => {

--- a/tests/unit/dom/ScriptElement.test.js
+++ b/tests/unit/dom/ScriptElement.test.js
@@ -10,6 +10,8 @@ describe('ScriptElement', () => {
       .then(o => {
         window = o.window;
         document = o.document;
+        
+        window.navigator.getVRDisplaysSync = () => [];
 
         window.onload = () => {
           cb();

--- a/tests/unit/dom/SrcableElement.test.js
+++ b/tests/unit/dom/SrcableElement.test.js
@@ -15,11 +15,19 @@ const videoData = fs.readFileSync(path.resolve(__dirname, '../data/test.mp4'), '
 const videoDataUri = `data:video/mp4;base64,${videoData}`;
 
 describe('HTMLSrcableElement', () => {
+  var window;
   var document;
   var el;
 
   beforeEach(() => {
-    document = exokit().document;
+    const o = exokit();
+    window = o.window;
+    window.navigator.getVRDisplaysSync = () => [];
+    document = o.document;
+  });
+  
+  afterEach(() => {
+    window.destroy();
   });
 
   describe('<img>', () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,10 +1,6 @@
 /* global describe */
 const exokit = require('../../index');
 
-module.exports.createWindow = function () {
-  return exokit().window;
-};
-
 /**
  * Test that is only run locally and is skipped on CI.
  */

--- a/tests/unit/timer/requestAnimationFrame.test.js
+++ b/tests/unit/timer/requestAnimationFrame.test.js
@@ -8,6 +8,8 @@ describe('requestAnimationFrame', () => {
     exokit.load('data:text/html,<html></html>')
       .then(o => {
         window = o.window;
+        window.navigator.getVRDisplaysSync = () => [];
+
         cb();
       });
   });

--- a/tests/unit/timer/setInterval.test.js
+++ b/tests/unit/timer/setInterval.test.js
@@ -8,6 +8,7 @@ describe('setInterval', () => {
     exokit.load('data:text/html,<html></html>')
       .then(o => {
         window = o.window;
+        window.navigator.getVRDisplaysSync = () => [];
         cb();
       });
   });

--- a/tests/unit/timer/setTimeout.test.js
+++ b/tests/unit/timer/setTimeout.test.js
@@ -8,6 +8,7 @@ describe('setTimeout', () => {
     exokit.load('data:text/html,<html></html>')
       .then(o => {
         window = o.window;
+        window.navigator.getVRDisplaysSync = () => [];
         cb();
       });
   });


### PR DESCRIPTION
Some sites/engines do not listen for `vrdisplayactivate` fast enough so they miss the initial event we send.

We try to not emit it until resource loading has "stopped" but that's not enough; some engines do a few more ticks afterwards before listening for the event.

The solution here is to wait a few frames (`100`) and try the event emit one more time, if there has not peen any XR boot by that point.