### PR TITLE
GLSL2 shaders: support layout()

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "upng-js": "^2.1.0",
     "vm-one": "0.0.13",
     "vr-display": "0.0.26",
-    "webgl-to-opengl": "0.0.7",
+    "webgl-to-opengl": "0.0.8",
     "window-classlist": "0.0.4",
     "window-fetch": "0.0.9",
     "window-selector": "0.0.5",


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/322.

This enables `layout` expressions in GLSL shaders: 

```
layout(location = 0) in vec3 fail;
```

Done by way of https://github.com/modulesio/webgl-to-opengl/pull/2, which enables the `GL_ARB_separate_shader_objects` extension.

```
#extension GL_ARB_separate_shader_objects : enable
```