### PR TITLE
Electron examples fixes

### DIFF
--- a/deps/exokit-bindings/canvascontext/src/imageData-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/imageData-context.cc
@@ -48,7 +48,7 @@ NAN_METHOD(ImageData::New) {
     unsigned int width = info[1]->Uint32Value();
     unsigned int height = info[2]->Uint32Value();
 
-    if (array->ByteLength() == (width * height * 4)) {
+    if (array->ByteLength() >= (width * height * 4)) {
       Local<ArrayBuffer> arrayBuffer = array->Buffer();
       const char *data = (const char *)arrayBuffer->GetContents().Data() + array->ByteOffset();
       imageData = new ImageData(data, width, height);

--- a/examples/electron.html
+++ b/examples/electron.html
@@ -4,7 +4,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/95/three.js"></script>
     <script src="https://threejs.org/examples/js/controls/OrbitControls.js"></script>
     <script>
-    
+
       const width = 2048;
       const height = 2048;
 

--- a/examples/electron.html
+++ b/examples/electron.html
@@ -71,40 +71,48 @@
           canvas.width = browserWindow.width;
           canvas.height = browserWindow.width;
           const offset = (browserWindow.width - browserWindow.height)/2;
+
+          browserWindow.loadURL('http://lol.com');
+          browserWindow.setFrameRate(15);
+
           browserWindow.on('paint', o => {
             // console.log('paint', o.data.length);
 
-            // console.log('got bytelength', o.data.byteLength, o.width, o.height, o.width * o.height * 4);
+            // console.log('paint', o.data.byteLength, o.width, o.height, o.width * o.height * 4);
             // console.log('paint', o.data);
             ctx.putImageData(new ImageData(o.data, o.width, o.height), o.x, o.y + offset);
             texture.needsUpdate = true;
           });
-          browserWindow.loadURL('https://google.com');
           browserWindow.on('dom-ready', async () => {
-            await browserWindow.setFrameRate(15);
             /* await browserWindow.insertCSS(`
               ::-webkit-scrollbar {
                 height: 30px;
                 width: 30px;
                 background: #e0e0e0;
               }
-              
+
               ::-webkit-scrollbar-thumb {
                 background: #4db6ac;
               }
-              
+
               ::-webkit-scrollbar-corner {
                 background: #cfcfcf;
               }
             `); */
             // await browserWindow.sendInputEvent({type: 'mouseMove', x: 10, y: 10});
             console.log('loaded');
-            
+
             setTimeout(async () => {
               browserWindow.destroy();
               elctrn.destroy();
               console.log('exited');
             }, 2000);
+          });
+          browserWindow.on('did-fail-load', () => {
+            console.log('failed to load!');
+
+            browserWindow.destroy();
+            elctrn.destroy();
           });
         })();
 

--- a/src/electron.js
+++ b/src/electron.js
@@ -63,6 +63,9 @@ const electron = {
                 if (type === 0) {
                   d = JSON.parse(d.toString('utf8'));
                 } else if (type === 1) {
+                  const dCopy = Buffer.allocUnsafe(d.length);
+                  d.copy(dCopy);
+                  d = dCopy;
                   // d = Buffer.from(d.toString('ascii'), 'hex');
                 } else {
                   console.warn('invalid message type', type);

--- a/src/electron.js
+++ b/src/electron.js
@@ -118,13 +118,15 @@ const electron = {
             createBrowserWindow(args) {
               return new Promise((accept, reject) => {
                 const id = ids++;
-                localChannel.emit(
-                  JSON.stringify({
-                    method: 'createBrowserWindow',
-                    id,
-                    args
-                  })
-                );
+                const b = Buffer.from(JSON.stringify({
+                  method: 'createBrowserWindow',
+                  id,
+                  args
+                }), 'utf8');
+                const lengthB = Buffer.allocUnsafe(Uint32Array.BYTES_PER_ELEMENT);
+                lengthB.writeUInt32LE(b.length, 0);
+                localChannel.emit(lengthB);
+                localChannel.emit(b);
 
                 _waitForResponse(id, ({width, height}) => {
                   class BrowserWindow extends EventEmitter {
@@ -137,13 +139,16 @@ const electron = {
                     loadURL(u) {
                       return new Promise((accept, reject) => {
                         const id = ids++;
-                        localChannel.emit(
-                          JSON.stringify({
-                            method: 'loadURL',
-                            id,
-                            args: u
-                          })
-                        );
+                        const b = Buffer.from(JSON.stringify({
+                          method: 'loadURL',
+                          id,
+                          args: u
+                        }), 'utf8');
+                        const lengthB = Buffer.allocUnsafe(Uint32Array.BYTES_PER_ELEMENT);
+                        lengthB.writeUInt32LE(b.length, 0);
+                        localChannel.emit(lengthB);
+                        localChannel.emit(b);
+
                         _waitForResponse(id, () => {
                           accept();
                         });
@@ -152,13 +157,16 @@ const electron = {
                     setFrameRate(frameRate) {
                       return new Promise((accept, reject) => {
                         const id = ids++;
-                        localChannel.emit(
-                          JSON.stringify({
-                            method: 'setFrameRate',
-                            id,
-                            args: frameRate
-                          })
-                        );
+                        const b = Buffer.from(JSON.stringify({
+                          method: 'setFrameRate',
+                          id,
+                          args: frameRate
+                        }), 'utf8');
+                        const lengthB = Buffer.allocUnsafe(Uint32Array.BYTES_PER_ELEMENT);
+                        lengthB.writeUInt32LE(b.length, 0);
+                        localChannel.emit(lengthB);
+                        localChannel.emit(b);
+
                         _waitForResponse(id, () => {
                           accept();
                         });
@@ -167,13 +175,16 @@ const electron = {
                     insertCSS(css) {
                       return new Promise((accept, reject) => {
                         const id = ids++;
-                        localChannel.emit(
-                          JSON.stringify({
-                            method: 'insertCSS',
-                            id,
-                            args: css
-                          })
-                        );
+                        const b = Buffer.from(JSON.stringify({
+                          method: 'insertCSS',
+                          id,
+                          args: css
+                        }), 'utf8');
+                        const lengthB = Buffer.allocUnsafe(Uint32Array.BYTES_PER_ELEMENT);
+                        lengthB.writeUInt32LE(b.length, 0);
+                        localChannel.emit(lengthB);
+                        localChannel.emit(b);
+
                         _waitForResponse(id, () => {
                           accept();
                         });
@@ -182,31 +193,40 @@ const electron = {
                     sendInputEvent(event) {
                       return new Promise((accept, reject) => {
                         const id = ids++;
-                        localChannel.emit(
-                          JSON.stringify({
-                            method: 'sendInputEvent',
-                            id,
-                            args: event
-                          })
-                        );
+                        const b = Buffer.from(JSON.stringify({
+                          method: 'sendInputEvent',
+                          id,
+                          args: event
+                        }), 'utf8');
+                        const lengthB = Buffer.allocUnsafe(Uint32Array.BYTES_PER_ELEMENT);
+                        lengthB.writeUInt32LE(b.length, 0);
+                        localChannel.emit(lengthB);
+                        localChannel.emit(b);
+
                         _waitForResponse(id, () => {
                           accept();
                         });
                       });
                     }
                     close() {
-                      localChannel.emit(
-                        JSON.stringify({
-                          method: 'close',
-                        })
-                      );
+                      const id = ids++;
+                      const b = Buffer.from(JSON.stringify({
+                        method: 'close',
+                      }), 'utf8');
+                      const lengthB = Buffer.allocUnsafe(Uint32Array.BYTES_PER_ELEMENT);
+                      lengthB.writeUInt32LE(b.length, 0);
+                      localChannel.emit(lengthB);
+                      localChannel.emit(b);
                     }
                     destroy() {
-                      localChannel.emit(
-                        JSON.stringify({
-                          method: 'destroy',
-                        })
-                      );
+                      const id = ids++;
+                      const b = Buffer.from(JSON.stringify({
+                        method: 'destroy',
+                      }), 'utf8');
+                      const lengthB = Buffer.allocUnsafe(Uint32Array.BYTES_PER_ELEMENT);
+                      lengthB.writeUInt32LE(b.length, 0);
+                      localChannel.emit(lengthB);
+                      localChannel.emit(b);
                     }
                   }
                   const browserWindow = new BrowserWindow(width, height);

--- a/src/electron.js
+++ b/src/electron.js
@@ -76,8 +76,10 @@ const electron = {
               break;
             }
           }
-          if (i < data.length) {
-            oldData = data.slice(i);
+          const tailLength = data.length - i;
+          if (tailLength > 0) {
+            oldData = Buffer.allocUnsafe(tailLength);
+            data.copy(oldData, 0, i, data.length);
           }
 
           for (let i = 0; i < datas.length; i++) {

--- a/src/electronWorker.js
+++ b/src/electronWorker.js
@@ -49,8 +49,10 @@ ipc.serve(function() {
         break;
       }
     }
-    if (i < data.length) {
-      oldData = data;
+    const tailLength = data.length - i;
+    if (tailLength > 0) {
+      oldData = Buffer.allocUnsafe(tailLength);
+      data.copy(oldData, 0, i, data.length);
     }
 
     for (let i = 0; i < datas.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/334.

We had some weirdness with race conditions in the Electron IPC, and the example failed to account for the case where Electron emits oversided buffers.

- Allow `ImageData` to accept oversized data arrays
- Cache `Buffer`s in Electron IPC to prevent `node`'s network subsystem from overwriting data under us