### PR TITLE
Bugfix electron cropping

### DIFF
--- a/src/electronWorker.js
+++ b/src/electronWorker.js
@@ -103,11 +103,9 @@ ipc.serve(function() {
         browserWindow.webContents.on('paint', (event, dirty, image) => {
           // message 1
           // image = image.crop(dirty);
-          const bitmap = image.toBitmap();
+          let b = image.getBitmap();
           const bitmapSize = image.getSize();
           // console.log('crop image', image.getSize(), dirty);
-          let b = Buffer.allocUnsafe(bitmap.length);
-          bitmap.copy(b);
           b = _cropImage(bitmapSize.width, bitmapSize.height, dirty.x, dirty.y, dirty.width, dirty.height, 4, b);
           // b = _flipImage(dirty.width, dirty.height, 4, b);
           // b = Buffer.from(b.toString('hex'), 'ascii');


### PR DESCRIPTION
Fixes issues in https://github.com/webmixedreality/exokit/pull/337.

This fixes some problems with using the Electron `NativeImage` `crop` functionality in our paint transfer. Basically `crop` (done via Skia in their code) seems to mess up the stride of the resultant bitmap, so we were blitting it incorrectly into the canvas.

The fix here is to do the damage blit ourselves in JS. This is probably _more_ performant than what we were doing before with the image flip (which is still necessary), since we are flipping less pixels now.