### PR TITLE
Remove canvas resize on create

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,8 +137,8 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
     window.devicePixelRatio = nativeWindowWidth / canvasWidth;
 
     // Tell DOM how large the window is.
-    canvas.height = window.innerHeight = nativeWindowHeight / window.devicePixelRatio;
-    canvas.width = window.innerWidth = nativeWindowWidth / window.devicePixelRatio;
+    window.innerHeight = nativeWindowHeight / window.devicePixelRatio;
+    window.innerWidth = nativeWindowWidth / window.devicePixelRatio;
 
     const title = `Exokit ${version}`;
     nativeWindow.setWindowTitle(windowHandle, title);


### PR DESCRIPTION
Follow-up to https://github.com/webmixedreality/exokit/pull/352.

I don't think setting `canvas.{width,height}` is doing anything except potentially recreating context to the same size it was.

- [x] Should verify before merging