### PR TITLE
have canvas clientWidth/clientHeight read from window.innerWidth/innerHeight

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1862,11 +1862,11 @@ class HTMLCanvasElement extends HTMLElement {
   }
 
   get clientWidth() {
-    return this.width / this.ownerDocument.defaultView.devicePixelRatio;
+    return this.ownerDocument.defaultView.innerWidth;
   }
   set clientWidth(clientWidth) {}
   get clientHeight() {
-    return this.height / this.ownerDocument.defaultView.devicePixelRatio;
+    return this.ownerDocument.defaultView.innerHeight;
   }
   set clientHeight(clientHeight) {}
 


### PR DESCRIPTION
The canvas client size will just be the window size, right?

I was having an issue where `canvas.width` and `canvas.height` was temporarily set as the default canvas size. `getBoundingClientRect` was reading from those when I expected the current window size.

For some reason, my issue didn't reproduce in simple A-Frame examples, but it did in larger ones. Where the canvas would visible start at a certain size, and then resize itself a short time later. And at the point my application initialized, `canvas.getBoundingClientRect` was returning the default canvas size.

This fixes for me, and perhaps reduces the repetition of the pixel ratio operation, and decouples the idea of the context size versus the represented size? Don't know if it's a hack or not.