### PR TITLE
ndb for debugging with a note in the README on how to use (fixes #246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,26 @@ Exokit runs on Windows, macOS, Linux (x64), and Linux (ARM64).
 - You don't care about 3D or mixed reality.
 - You're looking for strict and/or legacy standards support.
 
-## Keyboard
-![Keyboard](https://raw.githubusercontent.com/webmixedreality/exokit/master/assets/keyboard.png)
+## Debugging
 
+Uses [ndb](https://github.com/GoogleChromeLabs/ndb).
+
+```js
+npm run debug
+```
+
+Then in the console, input:
+
+```
+let window = await require('./index').load(yourUrl);
+```
+
+Now you have a handle on the window object as you test your application, and
+you can set `debugger` breakpoints and such.
+
+## Keyboard
+
+![Keyboard](https://raw.githubusercontent.com/webmixedreality/exokit/master/assets/keyboard.png)
 
 ## Community
 

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
   },
   "main": "index.js",
   "scripts": {
-    "install": "node ./preinstall.js && node-gyp rebuild",
     "build": "node-gyp build",
+    "debug": "ndb",
+    "install": "node ./preinstall.js && node-gyp rebuild",
     "lint": "eslint core.js index.js native-bindings.js src tests",
     "rebuild": "shx rm -rf node_modules && npm cache clean --force && npm install",
+    "serve": "serve examples",
     "start": "node .",
     "test:ci": "TEST_ENV=ci npm run test:command -- --full-trace --exit",
     "test:command": "mocha --full-trace tests/unit/__setup.test.js tests/unit/*.test.js tests/unit/**/*.test.js",
-    "test:watch": "npm run test:command -- --watch",
-    "serve": "serve examples"
+    "test:watch": "npm run test:command -- --watch"
   },
   "repository": {
     "type": "git",
@@ -87,6 +88,7 @@
     "eslint": "^5.2.0",
     "express": "^4.16.3",
     "mocha": "^5.2.0",
+    "ndb": "^1.0.23",
     "serve": "^9.4.0",
     "shx": "^0.3.2",
     "sinon": "^6.1.4"


### PR DESCRIPTION
Worked for me!

Open up ndb (not attached to a process).

Then `var window = await require('./index').load(URL)`.

And get a handle on the window to debug, or use the debugger.