### PR TITLE
Update Slack token

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -82,7 +82,7 @@ deploy:
 notifications:
   - provider: Slack
     auth_token:
-      secure: 45CGZx1wukHisNzZTeLLraViNfOZxzzjx5lCfcrBq57T+fCPvD0UkJ0v3Slc/ykJ6TL5feuLnp0CGrAwtlfNztcTdPNlpCkGuWskq1A+Ehw=
+      secure: 45CGZx1wukHisNzZTeLLrdh/drSuJqO3uRJ7nxgon5RBePIM0QLR7lUKX16kPgzb9wAYgGt7A9E+ph8V9eFg+vkPoBZaIiV6GaS0PG3Xa1o=
     channel: '#builds'
     on_build_success: false
     on_build_failure: true


### PR DESCRIPTION
Appveyor build were failing due to a rolled Slack API token (for notifications). This updates the secure Slack token to the current one.