### PR TITLE
Magic leap mesh normals

### DIFF
--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -306,7 +306,7 @@ void MeshRequest::Poll() {
       Local<Float32Array> positions = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), vertex, vertexCount * sizeof(MLVec3f)), 0, vertexCount * 3);
       obj->Set(JS_STR("positions"), positions);
 
-      MLVec3f *normal = blockMesh.vertex;
+      MLVec3f *normal = blockMesh.normal;
       Local<Float32Array> normals = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), normal, vertexCount * sizeof(MLVec3f)), 0, vertexCount * 3);
       obj->Set(JS_STR("normals"), normals);
 

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -836,6 +836,7 @@ NAN_METHOD(MLContext::Present) {
   if (MLMeshingInitSettings(&meshingSettings) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to initialize meshing settings", application_name);
   }
+  meshingSettings.flags |= MLMeshingFlags_ComputeNormals;
   /* meshingSettings.flags = MLMeshingFlags_ComputeNormals;
   meshingSettings.bounds_center = mlContext->position;
   meshingSettings.bounds_rotation = mlContext->rotation;


### PR DESCRIPTION
MLeap mesh normals were not passed down to the JS meshing API correctly -- it was just a copy of the position data, resulting in incorrect normals in materials in the examples.

- Add magic leap API flag to enable returning mesh normals
- Make mesh normals object return the actual mesh normals