### PR TITLE
Add GL BufferData null data support

### DIFF
--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -2820,6 +2820,10 @@ NAN_METHOD(WebGLRenderingContext::BufferData) {
     data = nullptr;
     size = info[1]->Uint32Value();
     usage = info[2]->Int32Value();
+  } else if (obj->IsNull() || obj->IsUndefined()) {
+    data = nullptr;
+    size = 0;
+    usage = info[2]->Int32Value();
   } else {
     Nan::ThrowError("bufferData: invalid arguments");
     return;


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bufferData#Syntax, this is allowed and used sometimes.