### PR TITLE
Magic leap multiplayer mesh buffer arrays

### DIFF
--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -92,12 +92,14 @@ public:
   MeshBuffer(GLuint positionBuffer, GLuint normalBuffer, GLuint indexBuffer);
   MeshBuffer(const MeshBuffer &meshBuffer);
   MeshBuffer();
-  void setBuffers(float *positions, uint32_t numPositions, float *normals, unsigned short *indices, uint16_t numIndices, bool isNew);
+  void setBuffers(float *positions, uint32_t numPositions, float *normals, uint16_t *indices, uint16_t numIndices, bool isNew);
 
   GLuint positionBuffer;
   GLuint normalBuffer;
   GLuint indexBuffer;
+  float *positions;
   uint32_t numPositions;
+  uint16_t *indices;
   uint16_t numIndices;
   bool isNew;
 };

--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -99,6 +99,7 @@ public:
   GLuint indexBuffer;
   float *positions;
   uint32_t numPositions;
+  float *normals;
   uint16_t *indices;
   uint16_t numIndices;
   bool isNew;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -262,7 +262,9 @@ MeshBuffer::MeshBuffer(GLuint positionBuffer, GLuint normalBuffer, GLuint indexB
   positionBuffer(positionBuffer),
   normalBuffer(normalBuffer),
   indexBuffer(indexBuffer),
+  positions(nullptr),
   numPositions(0),
+  indices(nullptr),
   numIndices(0),
   isNew(true)
   {}
@@ -274,7 +276,7 @@ MeshBuffer::MeshBuffer(const MeshBuffer &meshBuffer) {
   numIndices = meshBuffer.numIndices;
   isNew = meshBuffer.isNew;
 }
-MeshBuffer::MeshBuffer() : positionBuffer(0), normalBuffer(0), indexBuffer(0), numPositions(0), numIndices(0), isNew(true) {}
+MeshBuffer::MeshBuffer() : positionBuffer(0), normalBuffer(0), indexBuffer(0), positions(nullptr), numPositions(0), indices(nullptr), numIndices(0), isNew(true) {}
 
 void MeshBuffer::setBuffers(float *positions, uint32_t numPositions, float *normals, uint16_t *indices, uint16_t numIndices, bool isNew) {
   glBindBuffer(GL_ARRAY_BUFFER, positionBuffer);
@@ -286,7 +288,9 @@ void MeshBuffer::setBuffers(float *positions, uint32_t numPositions, float *norm
   glBindBuffer(GL_ARRAY_BUFFER, indexBuffer);
   glBufferData(GL_ARRAY_BUFFER, numIndices * sizeof(indices[0]), indices, GL_DYNAMIC_DRAW);
 
+  this->positions = positions;
   this->numPositions = numPositions;
+  this->indices = indices;
   this->numIndices = numIndices;
   this->isNew = isNew;
 }
@@ -371,17 +375,23 @@ void MLMesher::Poll() {
           obj->Set(JS_STR("id"), JS_STR(id));
           obj->Set(JS_STR("type"), JS_STR(meshBuffer.isNew ? "new" : "update"));
 
-          Local<Object> positionObj = Nan::New<Object>();
-          positionObj->Set(JS_STR("id"), JS_INT(meshBuffer.positionBuffer));
-          obj->Set(JS_STR("position"), positionObj);
+          Local<Object> positionBuffer = Nan::New<Object>();
+          positionBuffer->Set(JS_STR("id"), JS_INT(meshBuffer.positionBuffer));
+          obj->Set(JS_STR("positionBuffer"), positionBuffer);
+          Local<Float32Array> positionArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), meshBuffer.positions, meshBuffer.numPositions * sizeof(float)), 0, meshBuffer.numPositions);
+          obj->Set(JS_STR("positionArray"), positionArray);
           obj->Set(JS_STR("positionCount"), JS_INT(meshBuffer.numPositions));
-          Local<Object> normalObj = Nan::New<Object>();
-          normalObj->Set(JS_STR("id"), JS_INT(meshBuffer.normalBuffer));
-          obj->Set(JS_STR("normal"), normalObj);
+          Local<Object> normalBuffer = Nan::New<Object>();
+          normalBuffer->Set(JS_STR("id"), JS_INT(meshBuffer.normalBuffer));
+          obj->Set(JS_STR("normalBuffer"), normalBuffer);
+          Local<Float32Array> normalArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), meshBuffer.normals, meshBuffer.numPositions * sizeof(float)), 0, meshBuffer.numPositions);
+          obj->Set(JS_STR("normalArray"), normalArray);
           obj->Set(JS_STR("normalCount"), JS_INT(meshBuffer.numPositions));
-          Local<Object> indexObj = Nan::New<Object>();
-          indexObj->Set(JS_STR("id"), JS_INT(meshBuffer.indexBuffer));
-          obj->Set(JS_STR("index"), indexObj);
+          Local<Object> indexBuffer = Nan::New<Object>();
+          indexBuffer->Set(JS_STR("id"), JS_INT(meshBuffer.indexBuffer));
+          obj->Set(JS_STR("indexBuffer"), indexBuffer);
+          Local<Float32Array> indexArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), meshBuffer.normals, meshBuffer.numPositions * sizeof(float)), 0, meshBuffer.numPositions);
+          obj->Set(JS_STR("indexArray"), indexArray);
           obj->Set(JS_STR("count"), JS_INT(meshBuffer.numIndices));
 
           array->Set(numResults++, obj);

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -264,6 +264,7 @@ MeshBuffer::MeshBuffer(GLuint positionBuffer, GLuint normalBuffer, GLuint indexB
   indexBuffer(indexBuffer),
   positions(nullptr),
   numPositions(0),
+  normals(nullptr),
   indices(nullptr),
   numIndices(0),
   isNew(true)
@@ -272,11 +273,14 @@ MeshBuffer::MeshBuffer(const MeshBuffer &meshBuffer) {
   positionBuffer = meshBuffer.positionBuffer;
   normalBuffer = meshBuffer.normalBuffer;
   indexBuffer = meshBuffer.indexBuffer;
+  positions = meshBuffer.positions;
   numPositions = meshBuffer.numPositions;
+  normals = meshBuffer.normals;
+  indices = meshBuffer.indices;
   numIndices = meshBuffer.numIndices;
   isNew = meshBuffer.isNew;
 }
-MeshBuffer::MeshBuffer() : positionBuffer(0), normalBuffer(0), indexBuffer(0), positions(nullptr), numPositions(0), indices(nullptr), numIndices(0), isNew(true) {}
+MeshBuffer::MeshBuffer() : positionBuffer(0), normalBuffer(0), indexBuffer(0), positions(nullptr), numPositions(0), normals(nullptr), indices(nullptr), numIndices(0), isNew(true) {}
 
 void MeshBuffer::setBuffers(float *positions, uint32_t numPositions, float *normals, uint16_t *indices, uint16_t numIndices, bool isNew) {
   glBindBuffer(GL_ARRAY_BUFFER, positionBuffer);
@@ -290,6 +294,7 @@ void MeshBuffer::setBuffers(float *positions, uint32_t numPositions, float *norm
 
   this->positions = positions;
   this->numPositions = numPositions;
+  this->normals = normals;
   this->indices = indices;
   this->numIndices = numIndices;
   this->isNew = isNew;

--- a/docs/magicleap.md
+++ b/docs/magicleap.md
@@ -24,17 +24,29 @@ The type of update. Can be either:
 - `'update'`: the mesh was previously emitted as `new` but its data has changed. No action is necessary, but may be desired.
 - `'remove'`: the mesh is no longer in scope for the meshing system and should be discarded.
 
-#### `MLMeshUpdate.position : WebGLBuffer`
+#### `MLMeshUpdate.positionBuffer : WebGLBuffer`
 
-The raw `WebGLBuffer` for the mesh positions in world space. Represented as three `WebGLFloat` per vertex. Not in any particular order; indexed by `MLMeshUpdate.index`. Tightly packed stride.
+The opaque `WebGLBuffer` for the mesh positions in world space. Represented as three `WebGLFloat` per vertex. Not in any particular order; indexed by `MLMeshUpdate.indexBuffer`. Tightly packed stride.
 
-#### `MLMeshUpdate.normal : WebGLBuffer`
+#### `MLMeshUpdate.positionArray : Float32Array`
 
-The raw `WebGLBuffer` for the mesh normals. Represented as three `WebGLFloat` per vertex. Not in any particular order; indexed by `MLMeshUpdate.index`. Tightly packed stride.
+The `Float32Array` buffer that was uploaded to the `positionBuffer`.
 
-#### `MLMeshUpdate.index : WebGLBuffer`
+#### `MLMeshUpdate.normalBuffer : WebGLBuffer`
 
-The raw `WebGLBuffer` for the mesh indices for `MLMeshUpdate.position` and `MLMeshUpdate.normal`. Represented as three `WegGLShort` per triangle. Tightly packed stride.
+The opaque `WebGLBuffer` for the mesh normals. Represented as three `WebGLFloat` per vertex. Not in any particular order; indexed by `MLMeshUpdate.indexBuffer`. Tightly packed stride.
+
+#### `MLMeshUpdate.normalArray : Float32Array`
+
+The `Float32Array` buffer that was uploaded to the `normalBuffer`.
+
+#### `MLMeshUpdate.indexBuffer : WebGLBuffer`
+
+The opaque `WebGLBuffer` for the mesh indices for `MLMeshUpdate.position` and `MLMeshUpdate.normal`. Represented as three `WegGLShort` per triangle. Tightly packed stride.
+
+#### `MLMeshUpdate.indexArray : Uint16Array`
+
+The `Uint16Array` buffer that was uploaded to the `indexBuffer`.
 
 #### `MLMeshUpdate.count : Number`
 

--- a/examples/hello_ml.html
+++ b/examples/hello_ml.html
@@ -267,17 +267,17 @@
         mesh.frustumCulled = false;
         return mesh;
       };
-      const _loadTerrainMesh = (terrainMesh, {position, positionCount, normal, normalCount, index, count}) => {
+      const _loadTerrainMesh = (terrainMesh, {positionBuffer, positionCount, normalBuffer, normalCount, indexBuffer, count}) => {
         const {geometry} = terrainMesh;
         const attributes = renderer.getAttributes();
 
-        attributes.get(geometry.attributes.position).buffer = position;
+        attributes.get(geometry.attributes.position).buffer = positionBuffer;
         geometry.attributes.position.count = positionCount / 3;
 
-        attributes.get(geometry.attributes.normal).buffer = normal;
+        attributes.get(geometry.attributes.normal).buffer = normalBuffer;
         geometry.attributes.normal.count = normalCount / 3;
 
-        attributes.get(geometry.index).buffer = index;
+        attributes.get(geometry.index).buffer = indexBuffer;
         geometry.index.count = count / 1;
       };
       const _removeTerrainMesh = terrainMesh => {

--- a/examples/hello_ml.html
+++ b/examples/hello_ml.html
@@ -296,8 +296,7 @@
           const {id, type} = update;
 
           if (type === 'new' || type === 'update') {
-            const terrainMesh = _getTerrainMesh(id);
-            _loadTerrainMesh(terrainMesh, update);
+            _loadTerrainMesh(_getTerrainMesh(id), update);
           } else {
             const index = terrainMeshes.findIndex(terrainMesh => terrainMesh.meshId === id);
             if (index !== -1) {


### PR DESCRIPTION
This PR exposes the raw magic leap geometry buffer `Float32Array`/`Uint16Arrays` (indexed geometry) for consumption by sites that want it.

It's still uploaded to the GPU for e.g. depth buffer population, but the typed arrays format is also useful for e.g. blasting the geometry over the network to share the local space in multiplayer.