### PR TITLE
Bump native-audio-deps version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
-    "native-audio-deps": "0.0.45",
+    "native-audio-deps": "0.0.46",
     "native-canvas-deps": "0.0.48",
     "native-graphics-deps": "0.0.20",
     "native-openvr-deps": "0.0.17",


### PR DESCRIPTION
This includes the MacOS release only; the other OSes still need a rebuild.