### PR TITLE
Bump native-audio-deps to version 0.0.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
-    "native-audio-deps": "0.0.46",
+    "native-audio-deps": "0.0.47",
     "native-canvas-deps": "0.0.48",
     "native-graphics-deps": "0.0.20",
     "native-openvr-deps": "0.0.17",


### PR DESCRIPTION
This release contains the WebAudio bugfixes from https://github.com/modulesio/LabSound/pull/12 on all platforms:

- Windows
- MacOS (already in `0.0.46`)
- Linux
- Magic Leap (LuminOS)