### PR TITLE
Bugfix DocumentFragment GlobalContext circular dependency

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1946,7 +1946,7 @@ class HTMLTemplateElement extends HTMLElement {
   }
 
   get content() {
-    const content = new DocumentFragment();
+    const content = new GlobalContext.DocumentFragment();
     content.ownerDocument = this.ownerDocument;
     content.childNodes = new NodeList(this.childNodes);
     return content;

--- a/src/Document.js
+++ b/src/Document.js
@@ -337,6 +337,7 @@ class DocumentFragment extends DOM.HTMLElement {
   }
 }
 module.exports.DocumentFragment = DocumentFragment;
+GlobalContext.DocumentFragment = DocumentFragment;
 
 class Range extends DocumentFragment {
   constructor() {


### PR DESCRIPTION
This was unreferencable from `DOM.js`, generating stacks like the following:

```
09-11 14:35:50.990  3467     6 I exokit  : ReferenceError: DocumentFragment is not defined
09-11 14:35:50.990  3467     6 I exokit  :     at HTMLTemplateElement.get content [as content] (/package/src/DOM.js:1949:21)
09-11 14:35:50.990  3467     6 I exokit  :     at Schemas.templateHasOneOrZeroChildren (/js/vendor.bundled.js:86268:18)
09-11 14:35:50.990  3467     6 I exokit  :     at Schemas.validateTemplate (/js/vendor.bundled.js:86253:25)
09-11 14:35:50.990  3467     6 I exokit  :     at Schemas.add (/js/vendor.bundled.js:86196:20)
09-11 14:35:50.990  3467     6 I exokit  :     at window.addEventListener (/js/app.js:1:271393)
09-11 14:35:50.990  3467     6 I exokit  :     at emit (events.js:187:15)
09-11 14:35:50.990  3467     6 I exokit  :     at EventEmitter.emit (domain.js:442:20)
09-11 14:35:50.990  3467     6 I exokit  :     at _emit (/package/src/Event.js:56:40)
09-11 14:35:50.990  3467     6 I exokit  :     at window._emit (/package/core.js:1388:28)
09-11 14:35:50.990  3467     6 I exokit  :     at _emit (/package/src/Event.js:34:14)
```