### PR TITLE
Renderloop dirty GL

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -358,6 +358,6 @@ int main(int argc, char **argv) {
 
     ML_LOG_TAG(Info, LOG_TAG, "---------------------exokit end");
 
-      return 0;
+    return 0;
   }
 }


### PR DESCRIPTION
This fixes an issue where not dirtying the `<canvas>` WebGL context would cause the frame to not be submitted to the AR/VR device (especially magic leap). In some cases this is not tolerated well -- i.e. if you do not end a frame that you started the native loop will fail to render anymore.

- This changes it so that any time you have a dirty, visible context, it will go through the swapchain.
- Additionally, the Magic Leap case to always be considered dirty for swap purposes.