### PR TITLE
DOMContentLoaded: use setImmediate instead of process.nextTick

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -147,7 +147,7 @@ function initDocument (document, window) {
     });
   }
 
-  process.nextTick(async () => {
+  setImmediate(async () => {
     if (body) {
       const bodyChildNodes = body.childNodes;
       body.childNodes = new DOM.NodeList();


### PR DESCRIPTION
`A-Frame` seems to not like it if you submit `vrdisplayactivate` too soon. This manifests as the following stack:

```
09-12 17:00:48.464  2023     6 I exokit  : TypeError: Cannot read property 'el' of undefined
09-12 17:00:48.464  2023     6 I exokit  :     at HTMLElement.value (https://raw.githubusercontent.com/aframevr/a-painter/master/vendor/aframe-master.js:76047:47)
09-12 17:00:48.464  2023     6 I exokit  :     at enterVRBound (https://raw.githubusercontent.com/aframevr/a-painter/master/vendor/aframe-master.js:75921:48)
09-12 17:00:48.464  2023     6 I exokit  :     at emit (events.js:182:13)
09-12 17:00:48.464  2023     6 I exokit  :     at EventEmitter.emit (domain.js:442:20)
09-12 17:00:48.464  2023     6 I exokit  :     at _emit (/package/src/Event.js:56:40)
09-12 17:00:48.464  2023     6 I exokit  :     at window._emit (/package/src/core.js:1423:28)
09-12 17:00:48.464  2023     6 I exokit  :     at _emit (/package/src/Event.js:34:14)
09-12 17:00:48.464  2023     6 I exokit  :     at _recurse (/package/src/Event.js:42:7)
09-12 17:00:48.464  2023     6 I exokit  :     at dispatchEvent (/package/src/Event.js:52:5)
09-12 17:00:48.464  2023     6 I exokit  :     at _emitOneDisplay (/package/src/Document.js:213:16)
09-12 17:00:48.467  2023     6 I exokit  : TypeError: Cannot read property 'el' of undefined
09-12 17:00:48.467  2023     6 I exokit  :     at HTMLElement.value (https://raw.githubusercontent.com/aframevr/a-painter/master/vendor/aframe-master.js:76047:47)
09-12 17:00:48.467  2023     6 I exokit  :     at enterVRBound (https://raw.githubusercontent.com/aframevr/a-painter/master/vendor/aframe-master.js:75921:48)
```

Usually things succeed anyway on a later `vrdisplayactivate` but this softening of the event emit seems to reduce the frequency of the error (I believe by making Exokit more in line with browser event emit behavior).