### PR TITLE
Bump vm-one module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "repl.history": "^0.1.4",
     "rimraf": "^2.6.2",
     "upng-js": "^2.1.0",
-    "vm-one": "0.0.17",
+    "vm-one": "0.0.22",
     "vr-display": "0.0.26",
     "webgl-to-opengl": "0.0.9",
     "window-classlist": "0.0.4",


### PR DESCRIPTION
This is mostly a cleanup refactoring that happened while implementing https://github.com/webmixedreality/exokit/pull/465.