### PR TITLE
make window.Promise read-only and not overwritable by polyfills

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1540,6 +1540,18 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     }
   });
 
+  // Block polyfills from overwriting Promise object.
+  const originalWindowPromise = window.Promise;
+  Object.defineProperty(window, 'Promise', {
+    get() {
+      return originalWindowPromise;
+    },
+    set() {
+      console.warn('window.Promise cannot be overwritten.');
+      return;
+    }
+  });
+
   if (!parent) {
     window.tickAnimationFrame = tickAnimationFrame;
 

--- a/tests/unit/Window.test.js
+++ b/tests/unit/Window.test.js
@@ -1,0 +1,11 @@
+/* global assert, describe, it */
+const exokit = require('../../src/index');
+
+describe('Promise', () => {
+  it('cannot be overwritten', () => {
+    const window = exokit().window;
+    const originalPromise = window.Promise;
+    window.Promise = () => {};
+    assert.equal(window.Promise, originalPromise);
+  });
+});


### PR DESCRIPTION
The `normalizePrototype` fix from earlier did get us pass an explicit error, but now we have unexpected behavior from the Promise object being force-polyfilled by some sites.

With webvr.soundboxing.co using babel-polyfill, A-Frame did not like the Promise being overwritten. 
`Promise.all` was not working as expected, stopping the scene from loading. Perhaps to make it easier, don't allow Promise to be overwritten by polyfills that aren't needed.

