### PR TITLE
Events system DOMification

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1819,7 +1819,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
             }
           })
           .catch(err => {
-            console.error(err);
+            console.warn(err);
+
             this.dispatchEvent(new Event('load', {target: this}));
           })
           .finally(() => {

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2261,7 +2261,7 @@ class HTMLAudioElement extends HTMLMediaElement {
             progressEvent.loaded = 1;
             progressEvent.total = 1;
             progressEvent.lengthComputable = true;
-            this._emit(progressEvent);
+            this.dispatchEvent(progressEvent);
 
             this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
             this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));
@@ -2340,7 +2340,7 @@ class HTMLVideoElement extends HTMLMediaElement {
           progressEvent.loaded = 1;
           progressEvent.total = 1;
           progressEvent.lengthComputable = true;
-          this._emit(progressEvent);
+          this.dispatchEvent(progressEvent);
 
           this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
           this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -246,11 +246,11 @@ const _setAttributeRaw = (el, prop, value) => {
         value,
       };
       el.attrs.push(attr);
-      el.dispatchEvent('attribute', prop, value, null);
+      el.dispatchNodeEvent('attribute', prop, value, null);
     } else {
       const oldValue = attr.value;
       attr.value = value;
-      el.dispatchEvent('attribute', prop, value, oldValue);
+      el.dispatchNodeEvent('attribute', prop, value, oldValue);
     }
   }
 };
@@ -275,7 +275,7 @@ const _makeAttributesProxy = el => new Proxy(el.attrs, {
     if (index !== -1) {
       const oldValue = target[index].value;
       target.splice(index, 1);
-      el.dispatchEvent('attribute', prop, null, oldValue);
+      el.dispatchNodeEvent('attribute', prop, null, oldValue);
     }
     return true;
   },
@@ -535,10 +535,10 @@ class Element extends Node {
     });
     this.addEventListener('children', (addedNodes, removedNodes, previousSibling, nextSiblings) => {
       for (let i = 0; i < addedNodes.length; i++) {
-        addedNodes[i].dispatchEvent('attached');
+        addedNodes[i].dispatchNodeEvent('attached');
       }
       for (let i = 0; i < removedNodes.length; i++) {
-        removedNodes[i].dispatchEvent('removed');
+        removedNodes[i].dispatchNodeEvent('removed');
       }
     });
   }
@@ -617,8 +617,8 @@ class Element extends Node {
     if (this._children) { this._children.update(); }
 
     // Notify observers.
-    this.dispatchEvent('children', newChildren, EMPTY_ARRAY, this.childNodes[this.childNodes.length - 2] || null, null);
-    this.ownerDocument.dispatchEvent('domchange');
+    this.dispatchNodeEvent('children', newChildren, EMPTY_ARRAY, this.childNodes[this.childNodes.length - 2] || null, null);
+    this.ownerDocument.dispatchNodeEvent('domchange');
 
     return childNode;
   }
@@ -633,8 +633,8 @@ class Element extends Node {
         this._children.update();
       }
 
-      this.dispatchEvent('children', [], [childNode], this.childNodes[index - 1] || null, this.childNodes[index] || null);
-      this.ownerDocument.dispatchEvent('domchange');
+      this.dispatchNodeEvent('children', [], [childNode], this.childNodes[index - 1] || null, this.childNodes[index] || null);
+      this.ownerDocument.dispatchNodeEvent('domchange');
 
       return childNode;
     } else {
@@ -656,8 +656,8 @@ class Element extends Node {
         this._children.update();
       }
 
-      this.dispatchEvent('children', [newChild], [oldChild], this.childNodes[index - 1] || null, this.childNodes[index] || null);
-      this.ownerDocument.dispatchEvent('domchange');
+      this.dispatchNodeEvent('children', [newChild], [oldChild], this.childNodes[index - 1] || null, this.childNodes[index] || null);
+      this.ownerDocument.dispatchNodeEvent('domchange');
 
       return oldChild;
     } else {
@@ -674,8 +674,8 @@ class Element extends Node {
         this._children.update();
       }
 
-      this.dispatchEvent('children', [childNode], [], this.childNodes[index - 1] || null, this.childNodes[index + 1] || null);
-      this.ownerDocument.dispatchEvent('domchange');
+      this.dispatchNodeEvent('children', [childNode], [], this.childNodes[index - 1] || null, this.childNodes[index + 1] || null);
+      this.ownerDocument.dispatchNodeEvent('domchange');
     }
   }
   insertAfter(childNode, nextSibling) {
@@ -688,8 +688,8 @@ class Element extends Node {
         this._children.update();
       }
 
-      this.dispatchEvent('children', [childNode], [], this.childNodes[index] || null, this.childNodes[index + 2] || null);
-      this.ownerDocument.dispatchEvent('domchange');
+      this.dispatchNodeEvent('children', [childNode], [], this.childNodes[index] || null, this.childNodes[index + 2] || null);
+      this.ownerDocument.dispatchNodeEvent('domchange');
     }
   }
   insertAdjacentHTML(position, text) {
@@ -708,7 +708,7 @@ class Element extends Node {
           index,
           0,
         ].concat(newChildNodes));
-        this.parentNode.dispatchEvent('children', newChildNodes, [], null, null);
+        this.parentNode.dispatchNodeEvent('children', newChildNodes, [], null, null);
         break;
       }
       case 'afterbegin': {
@@ -717,7 +717,7 @@ class Element extends Node {
           0,
           0,
         ].concat(newChildNodes));
-        this.dispatchEvent('children', newChildNodes, [], null, null);
+        this.dispatchNodeEvent('children', newChildNodes, [], null, null);
         break;
       }
       case 'beforeend': {
@@ -726,7 +726,7 @@ class Element extends Node {
           this.childNodes.length,
           0,
         ].concat(newChildNodes));
-        this.dispatchEvent('children', newChildNodes, [], null, null);
+        this.dispatchNodeEvent('children', newChildNodes, [], null, null);
         break;
       }
       case 'afterend': {
@@ -736,7 +736,7 @@ class Element extends Node {
           index + 1,
           0,
         ].concat(newChildNodes));
-        this.parentNode.dispatchEvent('children', newChildNodes, [], null, null);
+        this.parentNode.dispatchNodeEvent('children', newChildNodes, [], null, null);
         break;
       }
       default: {
@@ -952,15 +952,15 @@ class Element extends Node {
       this._children.update();
     }
 
-    this.dispatchEvent('children', newChildNodes, oldChildNodes, null, null);
-    this.ownerDocument.dispatchEvent('domchange');
+    this.dispatchNodeEvent('children', newChildNodes, oldChildNodes, null, null);
+    this.ownerDocument.dispatchNodeEvent('domchange');
 
     _promiseSerial(newChildNodes.map(childNode => () => GlobalContext._runHtml(childNode, this.ownerDocument.defaultView)))
       .catch(err => {
         console.warn(err);
       });
 
-    this.dispatchEvent('innerHTML', innerHTML);
+    this.dispatchNodeEvent('innerHTML', innerHTML);
   }
 
   get innerText() {
@@ -1080,7 +1080,7 @@ class Element extends Node {
       topDocument[symbols.pointerLockElementSymbol] = this;
 
       process.nextTick(() => {
-        topDocument.dispatchEvent('pointerlockchange');
+        topDocument.dispatchNodeEvent('pointerlockchange');
       });
     }
   }
@@ -1092,7 +1092,7 @@ class Element extends Node {
       topDocument[symbols.fullscreenElementSymbol] = this;
 
       process.nextTick(() => {
-        topDocument.dispatchEvent('fullscreenchange');
+        topDocument.dispatchNodeEvent('fullscreenchange');
       });
     }
   }
@@ -1391,7 +1391,7 @@ class HTMLStyleElement extends HTMLLoadableElement {
 
   set innerHTML(innerHTML) {
     innerHTML = innerHTML + '';
-    this.dispatchEvent('innerHTML', innerHTML);
+    this.dispatchNodeEvent('innerHTML', innerHTML);
   }
 
   [symbols.runSymbol]() {
@@ -1472,7 +1472,7 @@ class HTMLLinkElement extends HTMLLoadableElement {
     if (this.isRunnable()) {
       const hrefAttr = this.attributes.href;
       if (hrefAttr) {
-        this.dispatchEvent('attribute', 'href', hrefAttr.value);
+        this.dispatchNodeEvent('attribute', 'href', hrefAttr.value);
         running = true;
       }
     }
@@ -1568,7 +1568,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
     innerHTML = innerHTML + '';
 
     this.childNodes = new NodeList([new Text(innerHTML)]);
-    this.dispatchEvent('innerHTML', innerHTML);
+    this.dispatchNodeEvent('innerHTML', innerHTML);
   }
 
   isRunnable() {
@@ -1655,7 +1655,7 @@ class HTMLSrcableElement extends HTMLLoadableElement {
   [symbols.runSymbol]() {
     const srcAttr = this.attributes.src;
     if (srcAttr) {
-      this.dispatchEvent('attribute', 'src', srcAttr.value);
+      this.dispatchNodeEvent('attribute', 'src', srcAttr.value);
     }
     return Promise.resolve();
   }
@@ -1809,10 +1809,10 @@ class HTMLIFrameElement extends HTMLSrcableElement {
               this.contentDocument = contentDocument;
 
               contentDocument.addEventListener('framebuffer', framebuffer => {
-                this.dispatchEvent('framebuffer', framebuffer);
+                this.dispatchNodeEvent('framebuffer', framebuffer);
               });
               contentWindow.addEventListener('destroy', e => {
-                parentWindow.dispatchEvent('destroy', e);
+                parentWindow.dispatchNodeEvent('destroy', e);
               });
 
               this.dispatchEvent(new Event('load', {target: this}));
@@ -1852,7 +1852,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
 
   destroy() {
     if (this.live) {
-      this.dispatchEvent('destroy');
+      this.dispatchNodeEvent('destroy');
       this.live = false;
     }
   }
@@ -2011,7 +2011,7 @@ class CharacterNode extends Node {
   set textContent(textContent) {
     this.value = textContent;
 
-    this.dispatchEvent('value');
+    this.dispatchNodeEvent('value');
   }
 
   get data() {
@@ -2020,7 +2020,7 @@ class CharacterNode extends Node {
   set data(data) {
     this.value = data;
 
-    this.dispatchEvent('value');
+    this.dispatchNodeEvent('value');
   }
   get length() {
     return this.value.length;
@@ -2453,11 +2453,11 @@ class HTMLVideoElement extends HTMLMediaElement {
           .then(() => {
             console.log('video download done');
             this.readyState = HTMLMediaElement.HAVE_ENOUGH_DATA;
-            this.dispatchEvent('canplay');
-            this.dispatchEvent('canplaythrough');
+            this.dispatchNodeEvent('canplay');
+            this.dispatchNodeEvent('canplaythrough');
           })
           .catch(err => {
-            this.dispatchEvent('error', err);
+            this.dispatchNodeEvent('error', err);
           });
       } else if (name === 'loop') {
         this.video.loop = !!value || value === '';
@@ -2547,7 +2547,7 @@ class HTMLVideoElement extends HTMLMediaElement {
     let sources;
     const srcAttr = this.attributes.src;
     if (srcAttr) {
-      this.dispatchEvent('attribute', 'src', srcAttr.value);
+      this.dispatchNodeEvent('attribute', 'src', srcAttr.value);
       running = true;
     } else if (sources = this.childNodes.filter(childNode => childNode.nodeType === Node.ELEMENT_NODE && childNode.matches('source'))) {
       for (let i = 0; i < sources.length; i++) {

--- a/src/Document.js
+++ b/src/Document.js
@@ -124,7 +124,7 @@ function initDocument (document, window) {
         if (runElQueue.length > 0) {
           _addRun(runElQueue.shift());
         } else {
-          document.dispatchEvent('flush');
+          document.dispatchNodeEvent('flush');
         }
       } else {
         runElQueue.push(fn);
@@ -140,7 +140,7 @@ function initDocument (document, window) {
       for (let i = 0; i < iframes.length; i++) {
         const iframe = iframes[i];
         if (iframe.contentDocument) {
-          iframe.contentDocument.dispatchEvent('pointerlockchange');
+          iframe.contentDocument.dispatchNodeEvent('pointerlockchange');
         }
       }
     });
@@ -149,7 +149,7 @@ function initDocument (document, window) {
       for (let i = 0; i < iframes.length; i++) {
         const iframe = iframes[i];
         if (iframe.contentDocument) {
-          iframe.contentDocument.dispatchEvent('fullscreenchange');
+          iframe.contentDocument.dispatchNodeEvent('fullscreenchange');
         }
       }
     });
@@ -312,7 +312,7 @@ class Document extends DOM.HTMLLoadableElement {
       topDocument[symbols.pointerLockElementSymbol] = null;
 
       process.nextTick(() => {
-        topDocument.dispatchEvent('pointerlockchange');
+        topDocument.dispatchNodeEvent('pointerlockchange');
       });
     }
   }
@@ -323,7 +323,7 @@ class Document extends DOM.HTMLLoadableElement {
       topDocument[symbols.fullscreenElementSymbol] = null;
 
       process.nextTick(() => {
-        topDocument.dispatchEvent('fullscreenchange');
+        topDocument.dispatchNodeEvent('fullscreenchange');
       });
     }
   }

--- a/src/Document.js
+++ b/src/Document.js
@@ -124,7 +124,7 @@ function initDocument (document, window) {
         if (runElQueue.length > 0) {
           _addRun(runElQueue.shift());
         } else {
-          document.emit('flush');
+          document.dispatchEvent('flush');
         }
       } else {
         runElQueue.push(fn);
@@ -140,7 +140,7 @@ function initDocument (document, window) {
       for (let i = 0; i < iframes.length; i++) {
         const iframe = iframes[i];
         if (iframe.contentDocument) {
-          iframe.contentDocument._emit('pointerlockchange');
+          iframe.contentDocument.dispatchEvent('pointerlockchange');
         }
       }
     });
@@ -149,7 +149,7 @@ function initDocument (document, window) {
       for (let i = 0; i < iframes.length; i++) {
         const iframe = iframes[i];
         if (iframe.contentDocument) {
-          iframe.contentDocument._emit('fullscreenchange');
+          iframe.contentDocument.dispatchEvent('fullscreenchange');
         }
       }
     });
@@ -312,7 +312,7 @@ class Document extends DOM.HTMLLoadableElement {
       topDocument[symbols.pointerLockElementSymbol] = null;
 
       process.nextTick(() => {
-        topDocument._emit('pointerlockchange');
+        topDocument.dispatchEvent('pointerlockchange');
       });
     }
   }
@@ -323,7 +323,7 @@ class Document extends DOM.HTMLLoadableElement {
       topDocument[symbols.fullscreenElementSymbol] = null;
 
       process.nextTick(() => {
-        topDocument._emit('fullscreenchange');
+        topDocument.dispatchEvent('fullscreenchange');
       });
     }
   }

--- a/src/Event.js
+++ b/src/Event.js
@@ -56,7 +56,6 @@ class EventTarget {
       const _emit = (node, event) => {
         const listeners = node._listeners[event.type];
 
-        // console.log('dispatch event 2', this.tagName, event && event.type, listeners && listeners.length); // XXX
 
         if (listeners && listeners.length > 0) {
           event.currentTarget = this;

--- a/src/Event.js
+++ b/src/Event.js
@@ -34,7 +34,6 @@ EventTarget.prototype = {
     const _emit = (node, event) => {
       const listeners = node._listeners[event.type];
 
-
       if (listeners && listeners.length > 0) {
         event.currentTarget = this;
 
@@ -75,7 +74,6 @@ EventTarget.prototype = {
       this._currentListeners = listeners;
       for (this._currentListenerIndex = 0; this._currentListenerIndex < listeners.length; this._currentListenerIndex++) {
         try {
-
           listeners[this._currentListenerIndex].apply(this, args);
         } catch (err) {
           console.warn(err);

--- a/src/Event.js
+++ b/src/Event.js
@@ -1,13 +1,12 @@
 const USKeyboardLayout = require('./USKeyboardLayout');
 const GlobalContext = require('./GlobalContext');
 
-class EventTarget {
-  constructor() {
-    this._listeners = {};
-    this._currentListeners = null;
-    this._currentListenerIndex = 0;
-  }
-
+function EventTarget() {
+  this._listeners = {};
+  this._currentListeners = null;
+  this._currentListenerIndex = 0;
+}
+EventTarget.prototype = {
   addEventListener(event, listener) {
     if (typeof listener === 'function') {
       if (!this._listeners[event]) {
@@ -15,7 +14,7 @@ class EventTarget {
       }
       this._listeners[event].push(listener);
     }
-  }
+  },
   removeEventListener(event, listener) {
     if (typeof listener === 'function' && this._listeners[event]) {
       const index = this._listeners[event].indexOf(listener);
@@ -27,7 +26,7 @@ class EventTarget {
         }
       }
     }
-  }
+  },
 
   dispatchEvent(event) {
     event.target = this;
@@ -65,7 +64,7 @@ class EventTarget {
       }
     };
     _recurse(this, event);
-  }
+  },
   
   dispatchNodeEvent(event) {
     const listeners = this._listeners[event];
@@ -85,8 +84,8 @@ class EventTarget {
       this._currentListeners = null;
       // this._currentListenerIndex = 0;
     }
-  }
-}
+  },
+};
 module.exports.EventTarget = EventTarget;
 
 class Event {

--- a/src/Event.js
+++ b/src/Event.js
@@ -30,10 +30,8 @@ class EventTarget {
   }
 
   dispatchEvent(event) {
-
     if (typeof event === 'string') {
       const listeners = this._listeners[event];
-
 
       if (listeners && listeners.length > 0) {
         const args = Array.from(arguments).slice(1);

--- a/src/MutationObserver.js
+++ b/src/MutationObserver.js
@@ -58,7 +58,7 @@ class MutationObserver {
         _attribute = (name, value, oldValue) => {
           this.handleAttribute(el, name, value, oldValue);
         };
-        el.on('attribute', _attribute);
+        el.addEventListener('attribute', _attribute);
       }
 
       _children = (addedNodes, removedNodes, previousSibling, nextSibling) => {
@@ -74,13 +74,13 @@ class MutationObserver {
           }
         }
       };
-      el.on('children', _children);
+      el.addEventListener('children', _children);
 
       if (this.options.characterData) {
         _value = () => {
           this.handleValue(el);
         };
-        el.on('value', _value);
+        el.addEventListener('value', _value);
       }
 
       this.bindings.set(el, [_attribute, _children, _value]);
@@ -103,13 +103,13 @@ class MutationObserver {
           _value,
         ] = bindings;
         if (_attribute) {
-          el.removeListener('attribute', _attribute);
+          el.removeEventListener('attribute', _attribute);
         }
         if (_children) {
-          el.removeListener('children', _children);
+          el.removeEventListener('children', _children);
         }
         if (_value) {
-          el.removeListener('value', _value);
+          el.removeEventListener('value', _value);
         }
         this.bindings.delete(el);
       }

--- a/src/core.js
+++ b/src/core.js
@@ -618,7 +618,7 @@ const _runHtml = (element, window) => {
       element.traverse(el => {
         const {id} = el;
         if (id) {
-          el.dispatchEvent('attribute', 'id', id);
+          el.dispatchNodeEvent('attribute', 'id', id);
         }
 
         if (el[symbols.runSymbol]) {
@@ -930,7 +930,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   }
 
   window.destroy = function() {
-    this.dispatchEvent('destroy', {window: this});
+    this.dispatchNodeEvent('destroy', {window: this});
   };
   window.URL = URL;
   window.console = console;
@@ -1415,7 +1415,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   };
   window.postMessage = function(data) {
     setImmediate(() => {
-      window.dispatchEvent('message', new MessageEvent(data));
+      window.dispatchNodeEvent('message', new MessageEvent(data));
     });
   };
   /*
@@ -1433,6 +1433,11 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   };
   window.dispatchEvent = function(event) {
     if (!this[symbols.disabledEventsSymbol][event.type]) {
+      Node.prototype.dispatchEvent.apply(this, arguments);
+    }
+  };
+  window.dispatchNodeEvent = function(type) {
+    if (!this[symbols.disabledEventsSymbol][type]) {
       Node.prototype.dispatchEvent.apply(this, arguments);
     }
   };
@@ -1528,9 +1533,9 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         dataPath: options.dataPath,
       })
         .then(newWindow => {
-          window.dispatchEvent('beforeunload');
-          window.dispatchEvent('unload');
-          window.dispatchEvent('navigate', newWindow);
+          window.dispatchNodeEvent('beforeunload');
+          window.dispatchNodeEvent('unload');
+          window.dispatchNodeEvent('navigate', newWindow);
 
           _destroyTimeouts(window);
         })
@@ -1679,7 +1684,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     window[symbols.mrDisplaysSymbol] = _cloneMrDisplays(top[symbols.mrDisplaysSymbol], window);
 
     top.addEventListener('vrdisplaypresentchange', e => {
-      window.dispatchEvent('vrdisplaypresentchange', e);
+      window.dispatchNodeEvent('vrdisplaypresentchange', e);
     });
   }
   return window;

--- a/src/core.js
+++ b/src/core.js
@@ -1438,7 +1438,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   };
   window.dispatchNodeEvent = function(type) {
     if (!this[symbols.disabledEventsSymbol][type]) {
-      Node.prototype.dispatchEvent.apply(this, arguments);
+      Node.prototype.dispatchNodeEvent.apply(this, arguments);
     }
   };
   Object.defineProperty(window, 'onload', {

--- a/src/core.js
+++ b/src/core.js
@@ -1431,8 +1431,8 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     load: undefined,
     error: undefined,
   };
-  window.dispatchEvent = function(type) {
-    if (typeof type === 'string' && !this[symbols.disabledEventsSymbol][type]) {
+  window.dispatchEvent = function(event) {
+    if (!this[symbols.disabledEventsSymbol][event.type]) {
       Node.prototype.dispatchEvent.apply(this, arguments);
     }
   };

--- a/src/core.js
+++ b/src/core.js
@@ -829,7 +829,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   for (const k in EventTarget.prototype) {
     window[k] = EventTarget.prototype[k];
   }
-  window._listeners = []; // EventTarget.constructor
+  EventTarget.call(window);
 
   window.window = window;
   window.self = window;

--- a/src/core.js
+++ b/src/core.js
@@ -1818,7 +1818,7 @@ exokit.setNativeBindingsModule = nativeBindingsModule => {
     decodeAudioData(arrayBuffer, successCallback, errorCallback) {
       return new Promise((resolve, reject) => {
         try {
-          let audioBuffer = this._decodeAudioDataSync(arrayBuffer);
+          const audioBuffer = this._decodeAudioDataSync(arrayBuffer);
           if (successCallback) {
             process.nextTick(() => {
               try {

--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
         nativeWindow.resizeRenderTarget(gl, width, height, framebuffer, colorTexture, depthStencilTexture, msFramebuffer, msColorTexture, msDepthStencilTexture);
       };
 
-      document.dispatchEvent('framebuffer', {
+      document.dispatchNodeEvent('framebuffer', {
         framebuffer,
         colorTexture,
         depthStencilTexture,
@@ -225,7 +225,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
       canvas._context = null;
 
       if (hidden) {
-        document.dispatchEvent('framebuffer', null);
+        document.dispatchNodeEvent('framebuffer', null);
       }
       canvas.ownerDocument.removeEventListener('domchange', ondomchange);
 

--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
         nativeWindow.resizeRenderTarget(gl, width, height, framebuffer, colorTexture, depthStencilTexture, msFramebuffer, msColorTexture, msDepthStencilTexture);
       };
 
-      document._emit('framebuffer', {
+      document.dispatchEvent('framebuffer', {
         framebuffer,
         colorTexture,
         depthStencilTexture,
@@ -205,7 +205,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
         }
       });
     };
-    canvas.ownerDocument.on('domchange', ondomchange);
+    canvas.ownerDocument.addEventListener('domchange', ondomchange);
 
     cleanups.push(() => {
       nativeWindow.setCurrentWindowContext(windowHandle);
@@ -225,9 +225,9 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
       canvas._context = null;
 
       if (hidden) {
-        document._emit('framebuffer', null);
+        document.dispatchEvent('framebuffer', null);
       }
-      canvas.ownerDocument.removeListener('domchange', ondomchange);
+      canvas.ownerDocument.removeEventListener('domchange', ondomchange);
 
       contexts.splice(contexts.indexOf(gl), 1);
 
@@ -247,7 +247,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
     contexts.push(gl);
     fps = nativeWindow.getRefreshRate();
 
-    canvas.ownerDocument.defaultView.on('unload', () => {
+    canvas.ownerDocument.defaultView.addEventListener('unload', () => {
       gl.destroy();
     });
 
@@ -364,9 +364,9 @@ if (nativeVr) {
             nativeWindow.resizeRenderTarget(context, canvas.width, canvas.height, fbo, tex, depthStencilTex, msFbo, msTex, msDepthStencilTex);
           }
         };
-        canvas.on('attribute', _attribute);
+        canvas.addEventListener('attribute', _attribute);
         cleanups.push(() => {
-          canvas.removeListener('attribute', _attribute);
+          canvas.removeEventListener('attribute', _attribute);
         });
 
         window.top.updateVrFrame({
@@ -478,9 +478,9 @@ if (nativeMl) {
               nativeWindow.resizeRenderTarget(context, canvas.width, canvas.height, fbo, tex, depthStencilTex, msFbo, msTex, msDepthStencilTex);
             }
           };
-          canvas.on('attribute', _attribute);
+          canvas.addEventListener('attribute', _attribute);
           cleanups.push(() => {
-            canvas.removeListener('attribute', _attribute);
+            canvas.removeEventListener('attribute', _attribute);
           });
 
           window.top.updateVrFrame({
@@ -616,7 +616,6 @@ if (nativeMl) {
 
       nativeMl.InitLifecycle(_mlLifecycleEvent, _mlKeyboardEvent);
     });
-    s.on('error', () => {});
   }
 }
 
@@ -775,11 +774,11 @@ const _getFrameTimeMin = () => 0;
 const _bindWindow = (window, newWindowCb) => {
   window.innerWidth = innerWidth;
   window.innerHeight = innerHeight;
-  window.on('unload', () => {
+  window.addEventListener('unload', () => {
     clearTimeout(timeout);
   });
-  window.on('navigate', newWindowCb);
-  window.document.on('paste', e => {
+  window.addEventListener('navigate', newWindowCb);
+  window.document.addEventListener('paste', e => {
     e.clipboardData = new window.DataTransfer();
     if (contexts.length > 0) {
       const context = contexts[0];
@@ -1003,11 +1002,11 @@ const _bindWindow = (window, newWindowCb) => {
   };
   window.setDirtyFrameTimeout = setDirtyFrameTimeout;
 
-  window.on('unload', () => {
+  window.addEventListener('unload', () => {
     clearTimeout(timeout);
   });
-  window.on('navigate', newWindowCb);
-  window.document.on('paste', e => {
+  window.addEventListener('navigate', newWindowCb);
+  window.document.addEventListener('paste', e => {
     e.clipboardData = new window.DataTransfer();
     if (contexts.length > 0) {
       const context = contexts[0];
@@ -1018,7 +1017,7 @@ const _bindWindow = (window, newWindowCb) => {
     }
   });
 
-  window.on('vrdisplaypresentchange', e => {
+  window.addEventListener('vrdisplaypresentchange', e => {
     if (e.display) {
       const gamepads = [leftGamepad, rightGamepad];
       for (let i = 0; i < gamepads.length; i++) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -148,7 +148,10 @@ module.exports._storeOriginalWindowPrototypes = function (window, prototypesSymb
   });
 };
 
-const _elementGetter = (self, attribute) => self.listeners(attribute)[0];
+const _elementGetter = (self, attribute) => {
+  const listeners = self._listeners[attribute];
+  return listeners && listeners[0];
+};
 module.exports._elementGetter = _elementGetter;
 
 const _elementSetter = (self, attribute, cb) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -155,13 +155,12 @@ const _elementGetter = (self, attribute) => {
 module.exports._elementGetter = _elementGetter;
 
 const _elementSetter = (self, attribute, cb) => {
+  if (self._listeners[attribute]) {
+    self._listeners[attribute].length = 0;
+  }
+
   if (typeof cb === 'function') {
     self.addEventListener(attribute, cb);
-  } else {
-    const listeners = self.listeners(attribute);
-    for (let i = 0; i < listeners.length; i++) {
-      self.removeEventListener(attribute, listeners[i]);
-    }
   }
 };
 module.exports._elementSetter = _elementSetter;


### PR DESCRIPTION
The existing way of doing event management for DOM events was a bit hacky. Every `EventTarget` was basically a `node` `EventEmitter`.

The problem with doing this is that some frameworks (notably A-Frame) have their own event system and have naming clashes with `node`-style `EventEmitter`. That is not the DOM API so Exokit was at fault here, necessitating renaming `emit` to `_emit` and other fragile weirdness.

This PR re-implements events in term of `addEventListener` with no `node`-style `EventEmitter`, which makes the code more readable and less fragile. This came about as a side-effect of debugging DOM event emits.