### PR TITLE
Audio/Video progress events

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2221,7 +2221,7 @@ class HTMLAudioElement extends HTMLMediaElement {
             progressEvent.loaded = 1;
             progressEvent.total = 1;
             progressEvent.lengthComputable = true;
-            this._dispatchEventOnDocumentReady(progressEvent);
+            this._emit(progressEvent);
 
             this._emit('canplay');
             this._emit('canplaythrough');
@@ -2295,7 +2295,7 @@ class HTMLVideoElement extends HTMLMediaElement {
           progressEvent.loaded = 1;
           progressEvent.total = 1;
           progressEvent.lengthComputable = true;
-          this._dispatchEventOnDocumentReady(progressEvent);
+          this._emit(progressEvent);
 
           this.dispatchEvent(new Event('canplay', {target: this}));
           this.dispatchEvent(new Event('canplaythrough', {target: this}));

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2216,6 +2216,13 @@ class HTMLAudioElement extends HTMLMediaElement {
           })
           .then(() => {
             this.readyState = HTMLMediaElement.HAVE_ENOUGH_DATA;
+
+            const progressEvent = new Event('progress', {target: this});
+            progressEvent.loaded = 1;
+            progressEvent.total = 1;
+            progressEvent.lengthComputable = true;
+            this._dispatchEventOnDocumentReady(progressEvent);
+
             this._emit('canplay');
             this._emit('canplaythrough');
           })

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2291,6 +2291,12 @@ class HTMLVideoElement extends HTMLMediaElement {
         const resource = this.ownerDocument.resources.addResource();
 
         setImmediate(() => {
+          const progressEvent = new Event('progress', {target: this});
+          progressEvent.loaded = 1;
+          progressEvent.total = 1;
+          progressEvent.lengthComputable = true;
+          this._dispatchEventOnDocumentReady(progressEvent);
+
           this.dispatchEvent(new Event('canplay', {target: this}));
           this.dispatchEvent(new Event('canplaythrough', {target: this}));
 


### PR DESCRIPTION
This PR gets things started with `<audio>` and `<video>` progress events on load completion.

Some engines use this as a check for resource loading being complete.