### PR TITLE
TimeRange for HTMLMediaElement

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2280,6 +2280,11 @@ class HTMLAudioElement extends HTMLMediaElement {
       this.audio.duration = duration;
     }
   }
+
+  get buffered() {
+    return new TimeRanges([0, this.duration]);
+  }
+  set buffered(buffered) {}
 };
 module.exports.HTMLAudioElement = HTMLAudioElement;
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2374,6 +2374,12 @@ class HTMLVideoElement extends HTMLMediaElement {
       this.video.close();
     }
   }
+
+  get buffered() {
+    return new TimeRanges([0, this.duration]);
+  }
+  set buffered(buffered) {}
+
   update() {
     if (this.video) {
       this.video.update();

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2186,6 +2186,26 @@ class HTMLImageElement extends HTMLSrcableElement {
 };
 module.exports.HTMLImageElement = HTMLImageElement;
 
+class TimeRanges {
+  constructor(ranges) {
+    this._ranges = ranges;
+  }
+
+  start(i) {
+    return this._ranges[i][0];
+  }
+
+  end(i) {
+    return this._ranges[i][1];
+  }
+
+  get length() {
+    return this._ranges.length;
+  }
+  set length(length) {}
+}
+module.exports.TimeRanges = TimeRanges;
+
 class HTMLAudioElement extends HTMLMediaElement {
   constructor(attrs = [], value = '') {
     super('AUDIO', attrs, value);


### PR DESCRIPTION
`<audio>` and `<video>` DOM elements are supposed to have a `buffered` [`TimeRanges`](https://developer.mozilla.org/en-US/docs/Web/API/TimeRanges) accessor, which specified the loaded range state of the media element.

This is notably used by A-Frame for media element load detection, and possibly other engines as well.

Related: https://github.com/webmixedreality/exokit/pull/472