### PR TITLE
<img>/<audio> load event timing

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2136,7 +2136,7 @@ class HTMLImageElement extends HTMLSrcableElement {
             });
           }))
           .then(() => {
-            this.dispatchEvent(new Event('load', {target: this}));
+            this._dispatchEventOnDocumentReady(new Event('load', {target: this}));
           })
           .catch(err => {
             console.warn('failed to load image:', src);
@@ -2144,7 +2144,7 @@ class HTMLImageElement extends HTMLSrcableElement {
             const e = new ErrorEvent('error', {target: this});
             e.message = err.message;
             e.stack = err.stack;
-            this.dispatchEvent(e);
+            this._dispatchEventOnDocumentReady(e);
           })
           .finally(() => {
             setImmediate(() => {
@@ -2262,8 +2262,8 @@ class HTMLAudioElement extends HTMLMediaElement {
             progressEvent.lengthComputable = true;
             this._emit(progressEvent);
 
-            this._emit('canplay');
-            this._emit('canplaythrough');
+            this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
+            this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));
           })
           .catch(err => {
             console.warn('failed to load audio:', src);
@@ -2271,7 +2271,7 @@ class HTMLAudioElement extends HTMLMediaElement {
             const e = new ErrorEvent('error', {target: this});
             e.message = err.message;
             e.stack = err.stack;
-            this.dispatchEvent(e);
+            this._dispatchEventOnDocumentReady(e);
           })
           .finally(() => {
             setImmediate(() => {
@@ -2341,8 +2341,8 @@ class HTMLVideoElement extends HTMLMediaElement {
           progressEvent.lengthComputable = true;
           this._emit(progressEvent);
 
-          this.dispatchEvent(new Event('canplay', {target: this}));
-          this.dispatchEvent(new Event('canplaythrough', {target: this}));
+          this._dispatchEventOnDocumentReady(new Event('canplay', {target: this}));
+          this._dispatchEventOnDocumentReady(new Event('canplaythrough', {target: this}));
 
           resource.setProgress(1);
         });

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -186,7 +186,7 @@ class Node extends EventTarget {
         if (this.ownerDocument.readyState === 'complete') {
           this.ownerDocument.removeEventListener('readystatechange', _readystatechange);
 
-          setImmediate(() => {
+          process.nextTick(() => {
             this.dispatchEvent.apply(this, args);
           });
         }

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -175,6 +175,25 @@ class Node extends EventTarget {
   cloneNode(deep = false) {
     return _cloneNode(deep, this);
   }
+
+  _dispatchEventOnDocumentReady() {
+    if (this.ownerDocument.readyState === 'complete') {
+      this.dispatchEvent.apply(this, arguments);
+    } else {
+      const args = Array.from(arguments);
+
+      const _readystatechange = () => {
+        if (this.ownerDocument.readyState === 'complete') {
+          this.ownerDocument.removeEventListener('readystatechange', _readystatechange);
+
+          setImmediate(() => {
+            this.dispatchEvent.apply(this, args);
+          });
+        }
+      };
+      this.ownerDocument.addEventListener('readystatechange', _readystatechange);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Browser seem to wait for dispatching `<img>` and `<audio>` `onload`/`onerror` until `document.onreadystatechange` sets `document.readyState === 'complete'`.

Exokit was not doing this; it was simply emitting `load`/`error` as fast as it could. Therefore by the time "document ready" happened (which is often when the real user code starts chugging for XR), the load events were often missed.

This PR fixes that by waiting to emit load events for media elements until the `ownerDocument` is in `'complete'` ready state.