### PR TITLE
Windows build ProjectRoot

### DIFF
--- a/metadata/exokit.iss
+++ b/metadata/exokit.iss
@@ -5,7 +5,7 @@
 #define MyAppURL "https://github.com/webmixedreality/exokit"
 #define MyAppExeName "exokit.cmd"
 #define MyIcon "exokit.ico"
-#define ProjectRoot "."
+#define ProjectRoot ".."
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.


### PR DESCRIPTION
Fixes the Windows build in Inno Setup `exokit.iss`.

Regressed with https://github.com/webmixedreality/exokit/pull/459.