### PR TITLE
document.createTextNode/createComment ownerDocument setting

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -54,8 +54,16 @@ function initDocument (document, window) {
     range.ownerDocument = document;
     return range;
   };
-  document.createTextNode = text => new DOM.Text(text);
-  document.createComment = comment => new DOM.Comment(comment);
+  document.createTextNode = text => {
+    const node = new DOM.Text(text);
+    node.ownerDocument = document;
+    return node;
+  }
+  document.createComment = comment => {
+    const node = new DOM.Comment(comment);
+    node.ownerDocument = document;
+    return node;
+  };
   document.createEvent = type => {
     switch (type) {
       case 'KeyboardEvent':


### PR DESCRIPTION
`document.{createTextNode,createComment}` is supposed to set the resultant `ownerDocument`.

There is wild code that depends on this being correct, and there's no reason for this not to be correct. ;)