### PR TITLE
Worker scripts fetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "window-fetch": "0.0.9",
     "window-selector": "0.0.5",
     "window-text-encoding": "0.0.2",
-    "window-worker": "0.0.82",
+    "window-worker": "0.0.83",
     "window-xhr": "0.0.19",
     "ws": "^6.0.0"
   },


### PR DESCRIPTION
Worker scripts fetching (`importScripts`) has a storied history. It's one of two cases where JS forces us to synchronously fetch something, blocking user code (the other being synchronous XHR, but that's rare and deprecated).

The bug here was that our `await` threading implementation in `child-process-thread` was not switching V8 `Context` correctly.

- Previously we tried to solve this issue with `child_process.spawnSync` but this won't work on platforms that don't allow you to `fork`, which is fair.
- We also tried to use native `fork` but that runs into duplicate V8 globals problems.
- This solves it by ticking the UV runloop inside of `importScripts` while we do a normal fetch.

This is simpler but less efficient if there is a busy runloop at `importScripts` time since we have to check the boolean on every tick. But luckily this is usually *not* the case, since a worker will probably load scripts first, not do some crazy async things first.

Fixes https://github.com/webmixedreality/exokit/issues/497.

