### PR TITLE
Bump webgl-to-opengl version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "upng-js": "^2.1.0",
     "vm-one": "0.0.22",
     "vr-display": "0.0.26",
-    "webgl-to-opengl": "0.0.10",
+    "webgl-to-opengl": "0.0.11",
     "window-classlist": "0.0.4",
     "window-fetch": "0.0.9",
     "window-selector": "0.0.5",


### PR DESCRIPTION
Pull in https://github.com/modulesio/webgl-to-opengl/pull/4.

This fixes more offsetting cases in fragment shader WebGL -> OpenGL compilation, sliding the injection position of `fragColor` declaration injection past whitespace and preprocessor directives.