### PR TITLE
Fix HTMLTemplateElement typo

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1971,7 +1971,7 @@ class HTMLTemplateElement extends HTMLElement {
   get content() {
     const content = new GlobalContext.DocumentFragment();
     content.ownerDocument = this.ownerDocument;
-    content.childNodes = new NodeList(this.childNodes);
+    content.childNodes = new NodeList(this._childNodes);
     return content;
   }
   set content(content) {}


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/501.

This gets `networked-aframe` working.

<img width="1902" alt="capture3" src="https://user-images.githubusercontent.com/6926057/45841198-0d375f00-bce7-11e8-8353-8de780df3b13.PNG">
