### PR TITLE
Bump window-worker version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "window-fetch": "0.0.9",
     "window-selector": "0.0.5",
     "window-text-encoding": "0.0.2",
-    "window-worker": "0.0.83",
+    "window-worker": "0.0.84",
     "window-xhr": "0.0.19",
     "ws": "^6.0.0"
   },


### PR DESCRIPTION
This pulls in https://github.com/modulesio/window-worker/pull/6, fixing `Worker` scripts loading.