### PR TITLE
Fix windows build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
-    "native-audio-deps": "0.0.52",
+    "native-audio-deps": "0.0.53",
     "native-canvas-deps": "0.0.48",
     "native-graphics-deps": "0.0.20",
     "native-openvr-deps": "0.0.17",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "window-fetch": "0.0.9",
     "window-selector": "0.0.5",
     "window-text-encoding": "0.0.2",
-    "window-worker": "0.0.96",
+    "window-worker": "0.0.97",
     "window-xhr": "0.0.19",
     "ws": "^6.0.0"
   },


### PR DESCRIPTION
Ingests https://github.com/modulesio/child-process-thread/commit/da3a80be4c3ca9b30ea29bd36457f8ac64ab712b, https://github.com/modulesio/window-worker/commit/107449517eaaf811d95792e5ea2ea91170ceb293#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R25.

The problem was that windows does anonymous pipe creation differently than unix. Additionally, patches the `native-audio-deps` build for Windows+MacOS+Linux.