### PR TITLE
Bugfix testRun.sh pathing

### DIFF
--- a/scripts/testRun.sh
+++ b/scripts/testRun.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-"./exokit.sh" --quit
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+"$DIR/exokit.sh" --quit
 
 exitCode=$?
 


### PR DESCRIPTION
`testRun.sh` was moved to `scripts/` but not run form there, resulting in:

```
bash : scripts/testRun.sh: line 3: ./exokit.sh: No such file or directory
```