### PR TITLE
Bugfix LuminOS (ML) Canvas2D fonts

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -11,12 +11,12 @@ let display, fakeDisplay;
 const RAY_COLOR = 0x44c2ff;
 const RAY_HIGHLIGHT_COLOR = new THREE.Color(RAY_COLOR).multiplyScalar(0.5).getHex();
 const rayDistance = 1;
-const menuWidth = 1;
-const menuHeight = 1;
-const menuWorldWidth = menuWidth;
-const menuWorldHeight = menuHeight * .1;
+const menuWidth = 1024;
+const menuHeight = menuWidth * 0.1;
+const menuWorldWidth = 1;
+const menuWorldHeight = menuWorldWidth / menuWidth * menuHeight;
 const menuPositionHeight = .3;
-const urlBarWidth = menuWidth;
+const urlBarWidth = menuWorldWidth;
 const urlBarHeight = menuHeight;
 const urlBarOffset = urlBarHeight;
 const fontSize = 60;
@@ -399,10 +399,11 @@ const _makeRig = () => {
       const material = new THREE.MeshBasicMaterial({
         map: texture,
         side: THREE.DoubleSide,
-        transparent: true,
-        alphaTest: 0.9,
+        // transparent: true,
+        // alphaTest: 0.9,
       });
       const mesh = new THREE.Mesh(geometry, material);
+      // mesh.position.y = -menuWorldHeight/2;
       mesh.frustumCulled = false;
 
       const text = DEFAULT_URL;
@@ -414,58 +415,22 @@ const _makeRig = () => {
       mesh.urlState = urlState;
 
       const _updateText = () => {
-        console.log('update text', urlState.text, urlState.cursor);
+        // console.log('update text', urlState.text, urlState.cursor);
 
         ctx.fillStyle = '#EEE';
         ctx.fillRect(0, 0, menuWidth, menuHeight*2);
 
+        ctx.fillStyle = '#000';
+        ctx.font = `${fontSize}px Arial`;
+        ctx.fillText(urlState.text, 10, urlBarHeight - 10*2 - 10);
 
-        ctx.fillStyle = '#563156';
-        ctx.fillRect(0, 0, urlBarWidth, 2048);
-        //                    .set(0, -0.5, -1)
-
-  //            ctx.fillStyle = '#RFF';
-  //            ctx.fillRect(5, urlBarOffset + 500, urlBarWidth - 10, urlBarHeight - 10);
-
-
-
-        ctx.fillStyle = '#FFF';
-        // ctx.font = `${fontSize}px Arial`;
-        // ctx.fillText(urlState.text, 10, urlBarHeight - 10*2 - 30);
-        //
-        // urlState.measures.length = 0;
-        // urlState.measures.push(0);
-        // const {width: barWidth} = ctx.measureText('[');
-        // for (let i = 1; i <= urlState.text.length; i++) {
-        //   const {width} = ctx.measureText('[' + urlState.text.slice(0, i) + ']');
-        //   urlState.measures.push(width - barWidth*2);
-        // }
-        //
-        // ctx.fillStyle = '#03a9f4';
-        // ctx.fillRect(20 + urlState.measures[urlState.cursor] - cursorWidth/2, 30, cursorWidth, urlBarHeight - 20*2);
-
-  //TEST
-          // ctx.font = `${fontSize}px Arial`;
-          // ctx.fillText(urlState.text, 10, urlBarHeight - 10*2 - 30);
-
-          urlState.measures.length = 0;
-          urlState.measures.push(0);
-          // const {width: barWidth} = ctx.measureText('[');
-          for (let i = 1; i <= urlState.text.length; i++) {
-            // const {width} = ctx.measureText('[' + urlState.text.slice(0, i) + ']');
-            const {width} = 4;
-            const {barWidth} = 4;
-            urlState.measures.push(width - barWidth*2);
-          }
-
-          ctx.fillStyle = '#03a9f4';
-          ctx.fillRect(20 + urlState.measures[urlState.cursor] - cursorWidth/2, 30, cursorWidth, urlBarHeight - 20*2);
-
-  //END TEST
-
-
-
-
+        urlState.measures.length = 0;
+        urlState.measures.push(0);
+        const {width: barWidth} = ctx.measureText('[');
+        for (let i = 1; i <= urlState.text.length; i++) {
+          const {width} = ctx.measureText('[' + urlState.text.slice(0, i) + ']');
+          urlState.measures.push(width - barWidth*2);
+        }
 
         texture.needsUpdate = true;
       };
@@ -1244,6 +1209,9 @@ if (navigator.xr && !query.fake) {
 
   console.log('loaded root in 2D');
 }
+
+// renderer.setAnimationLoop(animate);
+// _openRig(new THREE.Vector3(0, 1.5, -1), new THREE.Quaternion());
     </script>
   </body>
 </html>

--- a/metadata/fonts.xml
+++ b/metadata/fonts.xml
@@ -1,0 +1,19 @@
+<familyset version="23">
+  <family name="sans-serif">
+    <font weight="300" style="normal">/system/etc/ml/kali/Fonts/Lomino/Light/LominoUI_Lt.ttf</font>
+    <font weight="300" style="italic">/system/etc/ml/kali/Fonts/Lomino/LightItalic/LominoUI_LtIt.ttf</font>
+    <font weight="400" style="normal">/system/etc/ml/kali/Fonts/Lomino/Regular/LominoUI_Rg.ttf</font>
+    <font weight="400" style="italic">/system/etc/ml/kali/Fonts/Lomino/Italic/LominoUI_It.ttf</font>
+    <font weight="500" style="normal">/system/etc/ml/kali/Fonts/Lomino/Medium/LominoUI_Md.ttf</font>
+    <font weight="500" style="italic">/system/etc/ml/kali/Fonts/Lomino/MediumItalic/LominoUI_MdIt.ttf</font>
+    <font weight="700" style="normal">/system/etc/ml/kali/Fonts/Lomino/Bold/LominoUI_Bd.ttf</font>
+    <font weight="700" style="italic">/system/etc/ml/kali/Fonts/Lomino/BoldItalic/LominoUI_BdIt.ttf</font>
+    <font weight="900" style="normal">/system/etc/ml/kali/Fonts/Lomino/ExtraBold/LominoUI_XBd.ttf</font>
+    <font weight="900" style="italic">/system/etc/ml/kali/Fonts/Lomino/ExtraBoldItalic/LominoUI_XBdIt.ttf</font>
+  </family>
+
+  <alias name="arial" to="sans-serif" />
+  <alias name="helvetica" to="sans-serif" />
+  <alias name="tahoma" to="sans-serif" />
+  <alias name="verdana" to="sans-serif" />
+</familyset>

--- a/metadata/program-device.mabu
+++ b/metadata/program-device.mabu
@@ -90,6 +90,7 @@ DATAS = ../package.json : / \
   ../build/Release/exokit.node : /build/Release/exokit.node \
   ../node_modules/ : /node_modules/ \
   ../examples/ : /examples/ \
+  ../metadata/fonts.xml : /etc/fonts.xml
 
 # If you need to perform pre-build or post-build steps,
 # write Makefile snippets using double-colon rules in

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
     "native-audio-deps": "0.0.54",
-    "native-canvas-deps": "0.0.49",
+    "native-canvas-deps": "0.0.50",
     "native-graphics-deps": "0.0.20",
     "native-openvr-deps": "0.0.17",
     "native-video-deps": "0.0.30",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
     "native-audio-deps": "0.0.54",
-    "native-canvas-deps": "0.0.48",
+    "native-canvas-deps": "0.0.49",
     "native-graphics-deps": "0.0.20",
     "native-openvr-deps": "0.0.17",
     "native-video-deps": "0.0.30",


### PR DESCRIPTION
Magic Leap only supports one font at the moment (Lumino). It's available in the system image and is mounted, but Skia doesn't know how to pick it up by default.

This introduces a `fonts.xml` referencing the Lomino font, and a Skia update to load it.

Ingests https://github.com/modulesio/skia/pull/6.

Inspiration from [Servo's Lumin Runtime PR](https://github.com/servo/servo/pull/21985) for the `fonts.xml` trick, and @chrislatorres' [debug logging](https://github.com/modulesio/skia/pull/4/files).