### PR TITLE
Add initial window.event exposure

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1069,6 +1069,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     }
     return WebSocket;
   })(WebSocket);
+  window.event = new Event(); // XXX this needs to track the current event
   window.localStorage = new LocalStorage(path.join(options.dataPath, '.localStorage'));
   window.indexedDB = indexedDB;
   window.performance = performance;


### PR DESCRIPTION
Quick-fix for https://github.com/webmixedreality/exokit/issues/573.

This does not track the current event but satisfies some in-the-wild usages of `window.event`.