### PR TITLE
Bugfix baseUrl computation in utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ function _getBaseUrl(u) {
     baseUrl = url.format({
       protocol: parsedUrl.protocol || 'http:',
       host: parsedUrl.host || '127.0.0.1',
-      pathname: parsedUrl.pathname,
+      pathname: parsedUrl.pathname !== '/' ? parsedUrl.pathname.replace(/\/[^\/]*$/, '') : parsedUrl.pathname,
       search: parsedUrl.search,
     });
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ function _getBaseUrl(u) {
     baseUrl = url.format({
       protocol: parsedUrl.protocol || 'http:',
       host: parsedUrl.host || '127.0.0.1',
-      pathname: parsedUrl.pathname !== '/' ? parsedUrl.pathname.replace(/\/[^\/]*$/, '') : parsedUrl.pathname,
+      pathname: parsedUrl.pathname.replace(/\/[^\/]*$/, '') || '/',
       search: parsedUrl.search,
     });
   }


### PR DESCRIPTION
Previously paths like `/examples/browser` were incorrectly mapped to the baseUrl `/examples/browser`, when we should slice off the tail of the path to get `/example`.