### PR TITLE
DOM element on* listeners browserization

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -5,6 +5,7 @@ module.exports.elementSymbol = Symbol();
 module.exports.fullscreenElementSymbol = Symbol();
 module.exports.htmlTagsSymbol = Symbol();
 module.exports.idSymbol = Symbol();
+module.exports.listenerSymbol = Symbol();
 module.exports.mrDisplaysSymbol = Symbol();
 module.exports.optionsSymbol = Symbol();
 module.exports.pointerLockElementSymbol = Symbol();

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,17 +147,17 @@ module.exports._storeOriginalWindowPrototypes = function (window, prototypesSymb
   });
 };
 
-const _elementGetter = (self, attribute) => self.listeners(attribute)[0];
+const _elementGetter = (self, attribute) => self.listeners(attribute).filter(l => l[symbols.listenerSymbol])[0];
 module.exports._elementGetter = _elementGetter;
 
 const _elementSetter = (self, attribute, cb) => {
+  const listener = _elementGetter(self, attribute);
+  if (listener) {
+    self.removeEventListener(attriubute, listener);
+  }
+  
   if (typeof cb === 'function') {
     self.addEventListener(attribute, cb);
-  } else {
-    const listeners = self.listeners(attribute);
-    for (let i = 0; i < listeners.length; i++) {
-      self.removeEventListener(attribute, listeners[i]);
-    }
   }
 };
 module.exports._elementSetter = _elementSetter;

--- a/src/utils.js
+++ b/src/utils.js
@@ -153,11 +153,13 @@ module.exports._elementGetter = _elementGetter;
 const _elementSetter = (self, attribute, cb) => {
   const listener = _elementGetter(self, attribute);
   if (listener) {
-    self.removeEventListener(attriubute, listener);
+    self.removeEventListener(attribute, listener);
+    listener[symbols.listenerSymbol] = false;
   }
   
   if (typeof cb === 'function') {
     self.addEventListener(attribute, cb);
+    cb[symbols.listenerSymbol] = true;
   }
 };
 module.exports._elementSetter = _elementSetter;


### PR DESCRIPTION
This PR adds makes HTML element class `on*` listeners like `onload` and `onerror` behave much more like the browser.

Previously these setters would override all other listeners on the element, specifically `addEventListener()`, but the correct behavior is to treat the `.on*` as a single separate listener in addition to the other ones.

```
img = new Image();
img.src = 'https://gfddgfdg/fdsgdsfg.lol';
img.addEventListener('error', err => {console.log('error 1');});
img.onerror = err => {console.log('error 2'); };
img.onerror = err => {console.log('error 3'); };
```

Correct output:
```
error 1
error 3
```