### PR TITLE
Fix timeouts with massive GLTF resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "window-selector": "0.0.5",
     "window-text-encoding": "0.0.2",
     "window-worker": "0.0.97",
-    "window-xhr": "0.0.19",
+    "window-xhr": "0.0.20",
     "ws": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes `ETIMEDOUT`/`ECONNRESET` errors on `XMLHttpRequest` when the connection is shaky.

This manifested mostly when loading a large number (200+) of resources with GLTF loaders in THREE.js/A-Frame.

```
{ Error: connect ETIMEDOUT 5.9.124.40:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1113:14)
  errno: 'ETIMEDOUT',
  code: 'ETIMEDOUT',
  syscall: 'connect',
  address: '5.9.124.40',
  port: 443 }
```

The real bug was in `window-xhr`.

Ingests https://github.com/modulesio/window-xhr/pull/1.