### PR TITLE
added extra keypress event for keyCode 13 ( enter key ) it never gets fired otherwise.

### DIFF
--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -482,17 +482,6 @@ void APIENTRY keyCB(NATIVEwindow *window, int key, int scancode, int action, int
       evt,
     };
     CallEmitter(sizeof(argv)/sizeof(argv[0]), argv);
-	
-	// Shim keypress after keydown for return key
-	
-    if(key == 13 && action == GLFW_PRESS){
-      evt->Set(JS_STR("type"), JS_STR("keypress"));
-      Local<Value> argv[] = {
-        JS_STR("keypress"), // event name
-        evt,
-      };
-      CallEmitter(sizeof(argv)/sizeof(argv[0]), argv);
-    }
 
     if (action == GLFW_PRESS && isPrintable) {
       keyCB(window, charCode, scancode, GLFW_REPEAT, mods);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -485,14 +485,14 @@ void APIENTRY keyCB(NATIVEwindow *window, int key, int scancode, int action, int
 	
 	// Shim keypress after keydown for return key
 	
-	if(key == 13 && action == GLFW_PRESS){
-	  evt->Set(JS_STR("type"), JS_STR("keypress"));
-	  Local<Value> argv[] = {
-	    JS_STR("keypress"), // event name
-	    evt,
-	  };
-	  CallEmitter(sizeof(argv)/sizeof(argv[0]), argv);
-	}
+    if(key == 13 && action == GLFW_PRESS){
+      evt->Set(JS_STR("type"), JS_STR("keypress"));
+      Local<Value> argv[] = {
+        JS_STR("keypress"), // event name
+        evt,
+      };
+      CallEmitter(sizeof(argv)/sizeof(argv[0]), argv);
+    }
 
     if (action == GLFW_PRESS && isPrintable) {
       keyCB(window, charCode, scancode, GLFW_REPEAT, mods);

--- a/deps/exokit-bindings/glfw/src/glfw.cc
+++ b/deps/exokit-bindings/glfw/src/glfw.cc
@@ -482,6 +482,17 @@ void APIENTRY keyCB(NATIVEwindow *window, int key, int scancode, int action, int
       evt,
     };
     CallEmitter(sizeof(argv)/sizeof(argv[0]), argv);
+	
+	// Shim keypress after keydown for return key
+	
+	if(key == 13 && action == GLFW_PRESS){
+	  evt->Set(JS_STR("type"), JS_STR("keypress"));
+	  Local<Value> argv[] = {
+	    JS_STR("keypress"), // event name
+	    evt,
+	  };
+	  CallEmitter(sizeof(argv)/sizeof(argv[0]), argv);
+	}
 
     if (action == GLFW_PRESS && isPrintable) {
       keyCB(window, charCode, scancode, GLFW_REPEAT, mods);

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2072,6 +2072,9 @@ class HTMLIFrameElement extends HTMLSrcableElement {
   }
   sendKeyDown(key, modifiers) {
     this.browser && this.browser.sendKeyDown(key, modifiers);
+	if(key === 13){
+		this.browser.sendKeyPress(key, modifiers);
+	}
   }
   sendKeyUp(key, modifiers) {
     this.browser && this.browser.sendKeyUp(key, modifiers);

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2072,9 +2072,9 @@ class HTMLIFrameElement extends HTMLSrcableElement {
   }
   sendKeyDown(key, modifiers) {
     this.browser && this.browser.sendKeyDown(key, modifiers);
-	if(key === 13){
-		this.browser.sendKeyPress(key, modifiers);
-	}
+    if(key === 13){
+      this.browser.sendKeyPress(key, modifiers);
+    }
   }
   sendKeyUp(key, modifiers) {
     this.browser && this.browser.sendKeyUp(key, modifiers);


### PR DESCRIPTION
Essentially I forgot to test the enter key yesterday, I realized it didn't get fired because there was no `keypress` event for keyCode 13. This just sends the extra `keypress` event in that case and solves the issue. 