### PR TITLE
iframe.contentWindow.location.href set in onloadend event

### DIFF
--- a/deps/exokit-bindings/browser/src/browser.cpp
+++ b/deps/exokit-bindings/browser/src/browser.cpp
@@ -296,10 +296,13 @@ void Browser::loadImmediate(const std::string &url) {
     [this]() -> void {
       RunOnMainThread([&]() -> void {
         Nan::HandleScope scope;
-        
+        CefString loadUrl = browser_->GetMainFrame()->GetURL();
+        Local<Value> argv[] = {
+            JS_STR(loadUrl.ToString()),
+          };
         if (!this->onloadend.IsEmpty()) {
           Local<Function> onloadend = Nan::New(this->onloadend);
-          onloadend->Call(Nan::Null(), 0, nullptr);
+          onloadend->Call(Nan::Null(), sizeof(argv)/sizeof(argv[0]), argv);
         }
       });
     },

--- a/deps/exokit-bindings/browser/src/browser.cpp
+++ b/deps/exokit-bindings/browser/src/browser.cpp
@@ -156,7 +156,7 @@ BrowserClient::~BrowserClient() {}
 // Browser
 
 Browser::Browser(WebGLRenderingContext *gl, int width, int height, const std::string &url) : gl(gl), tex(0), initialized(false) {
-  ensureCurrentGlWindow(gl);
+  windowsystem::SetCurrentWindowContext(gl->windowHandle);
   
   glGenTextures(1, &tex);
 
@@ -352,7 +352,7 @@ void Browser::loadImmediate(const std::string &url) {
   RenderHandler *render_handler_ = new RenderHandler(
     [this](const CefRenderHandler::RectList &dirtyRects, const void *buffer, int width, int height) -> void {
       RunOnMainThread([&]() -> void {
-        ensureCurrentGlWindow(this->gl);
+        windowsystem::SetCurrentWindowContext(this->gl->windowHandle);
         
         glBindTexture(GL_TEXTURE_2D, this->tex);
         glPixelStorei(GL_UNPACK_ROW_LENGTH, width); // XXX save/restore these

--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -80,8 +80,6 @@
 using namespace v8;
 using namespace node;
 
-void ensureCurrentGlWindow(WebGLRenderingContext *gl);
-
 enum GlKey {
   GL_KEY_COMPOSE,
 };

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -36,15 +36,18 @@ void unregisterGLObj(GLuint obj); */
 
 #define JS_GL_CONSTANT(name) JS_GL_SET_CONSTANT(#name, GL_ ## name)
 
+void ensureCurrentGlWindow(WebGLRenderingContext *gl) {
+  if (gl->windowHandle) {
+    windowsystem::SetCurrentWindowContext(gl->windowHandle);
+  }
+}
+
 template<NAN_METHOD(F)>
 NAN_METHOD(glCallWrap) {
   Local<Object> glObj = info.This();
   WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(glObj);
   if (gl->live) {
-    if (gl->windowHandle) {
-      windowsystem::SetCurrentWindowContext(gl->windowHandle);
-    }
-
+    ensureCurrentGlWindow(gl);
     F(info);
   }
 }
@@ -53,10 +56,7 @@ NAN_METHOD(glSwitchCallWrap) {
   Local<Object> glObj = info.This();
   WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(glObj);
   if (gl->live) {
-    if (gl->windowHandle) {
-      windowsystem::SetCurrentWindowContext(gl->windowHandle);
-    }
-
+    ensureCurrentGlWindow(gl);
     F(info);
   }
 }

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -36,18 +36,15 @@ void unregisterGLObj(GLuint obj); */
 
 #define JS_GL_CONSTANT(name) JS_GL_SET_CONSTANT(#name, GL_ ## name)
 
-void ensureCurrentGlWindow(WebGLRenderingContext *gl) {
-  if (gl->windowHandle) {
-    windowsystem::SetCurrentWindowContext(gl->windowHandle);
-  }
-}
-
 template<NAN_METHOD(F)>
 NAN_METHOD(glCallWrap) {
   Local<Object> glObj = info.This();
   WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(glObj);
   if (gl->live) {
-    ensureCurrentGlWindow(gl);
+    if (gl->windowHandle) {
+      windowsystem::SetCurrentWindowContext(gl->windowHandle);
+    }
+
     F(info);
   }
 }
@@ -56,7 +53,10 @@ NAN_METHOD(glSwitchCallWrap) {
   Local<Object> glObj = info.This();
   WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(glObj);
   if (gl->live) {
-    ensureCurrentGlWindow(gl);
+    if (gl->windowHandle) {
+      windowsystem::SetCurrentWindowContext(gl->windowHandle);
+    }
+
     F(info);
   }
 }

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1881,8 +1881,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   
                   let onmessage = null;
                   this.contentWindow = {
-                    location:{
-                      href:loadedUrl
+                    location: {
+                      href: loadedUrl
                     },
                     postMessage(m) {
                       browser.postMessage(JSON.stringify(m));

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1846,7 +1846,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   const browser = new GlobalContext.nativeBrowser.Browser(context, context.canvas.ownerDocument.defaultView.innerWidth, context.canvas.ownerDocument.defaultView.innerHeight, url);
                   this.browser = browser;
                   
-                  let done = false, err = null;
+                  let done = false, err = null, loadedUrl = url;
                   const _makeLoadError = () => new Error('failed to load page');
                   this.browser.onloadend = () => {
                     done = true;
@@ -1861,7 +1861,10 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   await new Promise((accept, reject) => {
                     if (!done) {
                       this.browser.onloadend = (_url) => {
-                        this.contentWindow.location.href = _url;
+                        loadedUrl = _url;
+                        if (this.contentWindow) {
+                          this.contentWindow.location.href = _url;
+                        }
                         accept();
                       };
                       this.browser.onloaderror = () => {
@@ -1879,8 +1882,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   let onmessage = null;
                   this.contentWindow = {
                     location:{
-                      href:url
-                    }
+                      href:loadedUrl
+                    },
                     postMessage(m) {
                       browser.postMessage(JSON.stringify(m));
                     },

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2087,7 +2087,16 @@ class HTMLIFrameElement extends HTMLSrcableElement {
   runJs(jsString = '', scriptUrl = '<unknown>', startLine = 1) {
     this.browser && this.browser.runJs(jsString, scriptUrl, startLine);
   }
-
+  
+  runCss(styleString){
+    this.browser && this.browser.runJs(`
+      var s = document.createElement('style');
+      s.setAttribute('type', 'text/css');
+      s.appendChild(document.createTextNode(`+style+`));
+      document.body.prependChild(s);`
+    );
+  }
+  
   destroy() {
     if (this.live) {
       this._emit('destroy');

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1858,15 +1858,14 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   this.browser.onconsole = (message, source, line) => {
                     this.onconsole && this.onconsole(message, source, line);
                   };
-                  
-                  let onmessage = null;
+                  let onmessage = null, setAttribute = this.setAttribute.bind(this);
                   this.contentWindow = {
                     location:{
                       get href() {
                         return loadedUrl;
                       },
                       set href(_url) {
-                        return this.setAttribute('src',_url);
+                        return setAttribute('src',_url);
                       },
                     },
                     postMessage(m) {

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1845,6 +1845,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                 if (context) {
                   const browser = new GlobalContext.nativeBrowser.Browser(context, context.canvas.ownerDocument.defaultView.innerWidth, context.canvas.ownerDocument.defaultView.innerHeight, url);
                   this.browser = browser;
+                  
                   let done = false, err = null;
                   const _makeLoadError = () => new Error('failed to load page');
                   this.browser.onloadend = () => {
@@ -1895,6 +1896,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   this.contentDocument = {};
 
                   this.readyState = 'complete';
+                  
                   this.dispatchEvent(new Event('load', {target: this}));
 
                   cb();

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1845,7 +1845,6 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                 if (context) {
                   const browser = new GlobalContext.nativeBrowser.Browser(context, context.canvas.ownerDocument.defaultView.innerWidth, context.canvas.ownerDocument.defaultView.innerHeight, url);
                   this.browser = browser;
-
                   let done = false, err = null;
                   const _makeLoadError = () => new Error('failed to load page');
                   this.browser.onloadend = () => {
@@ -1860,7 +1859,8 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   };
                   await new Promise((accept, reject) => {
                     if (!done) {
-                      this.browser.onloadend = () => {
+                      this.browser.onloadend = (_url) => {
+                        this.dispatchEvent(new MessageEvent('navigate', {data: _url}));
                         accept();
                       };
                       this.browser.onloaderror = () => {
@@ -1895,7 +1895,6 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   this.contentDocument = {};
 
                   this.readyState = 'complete';
-                  
                   this.dispatchEvent(new Event('load', {target: this}));
 
                   cb();

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2088,15 +2088,6 @@ class HTMLIFrameElement extends HTMLSrcableElement {
     this.browser && this.browser.runJs(jsString, scriptUrl, startLine);
   }
   
-  runCss(styleString){
-    this.browser && this.browser.runJs(`
-      var s = document.createElement('style');
-      s.setAttribute('type', 'text/css');
-      s.appendChild(document.createTextNode(`+style+`));
-      document.body.prependChild(s);`
-    );
-  }
-  
   destroy() {
     if (this.live) {
       this._emit('destroy');

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1858,24 +1858,6 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                   this.browser.onconsole = (message, source, line) => {
                     this.onconsole && this.onconsole(message, source, line);
                   };
-                  await new Promise((accept, reject) => {
-                    if (!done) {
-                      this.browser.onloadend = (_url) => {
-                        loadedUrl = _url;
-                        this.dispatchEvent(new Event('load', {target: this}));
-                        accept();
-                      };
-                      this.browser.onloaderror = () => {
-                        reject(_makeLoadError());
-                      };
-                    } else {
-                      if (!err) {
-                        accept();
-                      } else {
-                        reject(err);
-                      }
-                    }
-                  });
                   
                   let onmessage = null;
                   this.contentWindow = {
@@ -1886,7 +1868,7 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                       set href(_url) {
                         return this.setAttribute('src',_url);
                       },
-                    }
+                    },
                     postMessage(m) {
                       browser.postMessage(JSON.stringify(m));
                     },
@@ -1902,9 +1884,30 @@ class HTMLIFrameElement extends HTMLSrcableElement {
                       } : null;
                     },
                   };
+                  
                   this.contentDocument = {};
-
-                  this.readyState = 'complete';
+                  
+                  await new Promise((accept, reject) => {
+                    if (!done) {
+                      this.browser.onloadend = (_url) => {
+                        loadedUrl = _url;
+                        
+                        this.readyState = 'complete';
+                        
+                        this.dispatchEvent(new Event('load', {target: this}));
+                        accept();
+                      };
+                      this.browser.onloaderror = () => {
+                        reject(_makeLoadError());
+                      };
+                    } else {
+                      if (!err) {
+                        accept();
+                      } else {
+                        reject(err);
+                      }
+                    }
+                  });
 
                   cb();
                 } else {


### PR DESCRIPTION
Maybe this should have been in another PR but it only seemed to affect the browser so i said i would include it here - I added ensureCurrentGlWindow back into webgl.cc - maybe it was removed in a rebase regression? I'm probably making assumptions here and you removed it for good reason but i noticed the browser code depended on it and it was still in the header but not in the source. Anyway I couldn't see a good reason for its removal so i added it back in, hope i didn't over step!

Now for the main reason for this PR: 
Added in current URL to loadend event and dispatched on the front end on the iframe element as a `navigate` event - this way if the page loaded navigates somewhere else we get the URL of the new page passed back to the javascript side. Maybe I'm hijacking the loadend and this might be cleaner in its own event but i said i would show this working and not spend a lot of time on it if its not appropriate here. 