### PR TITLE
Reality tabs: far depth

### DIFF
--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -214,6 +214,8 @@ bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint
 #endif
     // glFramebufferTexture2DMultisampleEXT(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, msColorTex, 0, samples);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, msColorTex, 0);
+    
+    glClear(GL_DEPTH_BUFFER_BIT); // initialize to far depth
   }
   {
     glGenFramebuffers(1, &fbo);
@@ -240,6 +242,8 @@ bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTex, 0);
+    
+    glClear(GL_DEPTH_BUFFER_BIT); // initialize to far depth
   }
 
   bool framebufferOk = (glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);


### PR DESCRIPTION
Reality tabs are currently initialized with a depth texture of zeroes. This means the new tab wins the depth test before any rendering has started. Therefore if it misses the first frame (very likely), it will cause a display wipe until the tab starts to render.

To the user this appears as a black blink glitch.

This change adds a depth clear to render target context creation so that reality tabs start with far depth, avoiding an overwrite before the tabs' rendering has started.