### PR TITLE
WebXR hit test API

### DIFF
--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -94,6 +94,18 @@ public:
   uint32_t modifier_mask;
 };
 
+class MLRaycaster : public ObjectWrap {
+public:
+  MLRaycaster(MLHandle requestHandle, Local<Function> cb);
+  ~MLRaycaster();
+
+  bool Poll();
+
+// protected:
+  MLHandle requestHandle;
+  Nan::Persistent<Function> cb;
+};
+
 class MeshBuffer {
 public:
   MeshBuffer(GLuint positionBuffer, GLuint normalBuffer, GLuint indexBuffer);

--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -34,6 +34,7 @@
 #include <ml_privilege_ids.h>
 #include <ml_privilege_functions.h>
 #include <ml_input.h>
+#include <ml_raycast.h>
 #include <ml_gesture.h>
 #include <ml_lifecycle.h>
 #include <ml_logging.h>

--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -252,6 +252,7 @@ public:
   static NAN_METHOD(OnPresentChange);
   static NAN_METHOD(RequestMeshing);
   static NAN_METHOD(RequestPlaneTracking);
+  static NAN_METHOD(RequestHitTest);
   static NAN_METHOD(RequestHandTracking);
   static NAN_METHOD(RequestEyeTracking);
   static NAN_METHOD(RequestImageTracking);

--- a/deps/exokit-bindings/magicleap/include/ml-math.h
+++ b/deps/exokit-bindings/magicleap/include/ml-math.h
@@ -20,6 +20,7 @@ MLVec3f normalizeVector(const MLVec3f &v);
 MLVec3f applyVectorMatrix(const MLVec3f &v, const MLMat4f &m);
 float quaternionLength(const MLQuaternionf &q);
 MLQuaternionf normalizeQuaternion(const MLQuaternionf &q);
+MLQuaternionf multiplyQuaternions(const MLQuaternionf &qa, const MLQuaternionf &qb);
 MLQuaternionf getQuaternionFromUnitVectors(const MLVec3f &vFrom, const MLVec3f &vTo);
 MLVec3f getTriangleNormal(const MLVec3f &a, const MLVec3f &b, const MLVec3f &c);
 void orthonormalizeVectors(MLVec3f &normal, MLVec3f &tangent);

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -301,6 +301,7 @@ bool MLRaycaster::Poll() {
   if (result == MLResult_Ok) {
     Local<Object> asyncObject = Nan::New<Object>();
     AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLRaycaster::Poll");
+    Local<Function> cb = Nan::New(this->cb);
     
     if (raycastResult.state == MLRaycastResultState_HitObserved) {
       const MLVec3f &position = raycastResult.hitpoint;
@@ -309,7 +310,6 @@ bool MLRaycaster::Poll() {
       const MLVec3f &scale = {1, 1, 1};
       const MLMat4f &hitMatrix = composeMatrix(position, quaternion, scale);
 
-      Local<Function> cb = Nan::New(this->cb);
       Local<Object> xrHitResult = Nan::New<Object>();
       Local<Float32Array> hitMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), hitMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
       xrHitResult->Set(JS_STR("hitMatrix"), hitMatrixArray);

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -1495,6 +1495,7 @@ Handle<Object> MLContext::Initialize(Isolate *isolate) {
   Nan::SetMethod(ctorFn, "IsPresent", IsPresent);
   Nan::SetMethod(ctorFn, "IsSimulated", IsSimulated);
   Nan::SetMethod(ctorFn, "OnPresentChange", OnPresentChange);
+  Nan::SetMethod(ctorFn, "RequestHitTest", RequestHitTest);
   Nan::SetMethod(ctorFn, "RequestMeshing", RequestMeshing);
   Nan::SetMethod(ctorFn, "RequestPlaneTracking", RequestPlaneTracking);
   Nan::SetMethod(ctorFn, "RequestHandTracking", RequestHandTracking);
@@ -2595,6 +2596,24 @@ NAN_METHOD(MLContext::RequestPlaneTracking) {
     info.GetReturnValue().Set(mlPlaneTrackerObj);
   } else {
     Nan::ThrowError("MLContext::RequestPlaneTracking: invalid arguments");
+  }
+}
+
+NAN_METHOD(MLContext::RequestHitTest) {
+  if (
+    info[0]->IsObject() && Local<Object>::Cast(info[0])->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"))->StrictEquals(JS_STR("XRRay")) &&
+    info[1]->IsFunction()
+  ) {
+    Local<Object> xrRay = Local<Object>::Cast(info[0]);
+    Local<Float32Array> transformMatrix = Local<Float32Array>::Cast(xrRay->Get(JS_STR("transformMatrix")));
+    Local<Function> cbFn = Local<Function>::Cast(info[1]);
+
+    // XXX trigger MLRaycastQuery
+    
+    Local<Array> result = Nan::New<Array>(0);
+    info.GetReturnValue().Set(result);
+  } else {
+    Nan::ThrowError("MLContext::RequestHitTest: invalid arguments");
   }
 }
 

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2922,7 +2922,7 @@ NAN_METHOD(MLContext::Update) {
       } else {
         return false;
       }
-    ), raycasters.end());
+    }), raycasters.end());
   }
 
   if (handTrackers.size() > 0) {

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -296,15 +296,15 @@ MLRaycaster::MLRaycaster(MLHandle requestHandle, Local<Function> cb) : requestHa
 MLRaycaster::~MLRaycaster() {}
 
 bool MLRaycaster::Poll() {
-  MLRaycastResult result;
-  MLResult result = MLRaycastGetResult(raycastTracker, this->requestHandle, &result);
+  MLRaycastResult raycastResult;
+  MLResult result = MLRaycastGetResult(raycastTracker, this->requestHandle, &raycastResult);
   if (result == MLResult_Ok) {
     Local<Object> asyncObject = Nan::New<Object>();
     AsyncResource asyncResource(Isolate::GetCurrent(), asyncObject, "MLRaycaster::Poll");
     
-    if (result.state == MLRaycastResultState_HitObserved) {
-      const MLVec3f &position = result.hitpoint;
-      const MLVec3f &normal = result.normal;
+    if (raycastResult.state == MLRaycastResultState_HitObserved) {
+      const MLVec3f &position = raycastResult.hitpoint;
+      const MLVec3f &normal = raycastResult.normal;
       const MLQuaternionf &quaternion = getQuaternionFromUnitVectors(MLVec3f{0, 0, -1}, normal);
       const MLVec3f &scale = {1, 1, 1};
       const MLMat4f &hitMatrix = composeMatrix(position, quaternion, scale);

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2916,7 +2916,7 @@ NAN_METHOD(MLContext::Update) {
 
   if (raycasters.size() > 0) {
     raycasters.erase(std::remove_if(raycasters.begin(), raycasters.end(), [&](MLRaycaster *r) -> bool {
-      if (r.Poll()) {
+      if (r->Poll()) {
         delete r;
         return true;
       } else {

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -311,7 +311,7 @@ bool MLRaycaster::Poll() {
       const MLMat4f &hitMatrix = composeMatrix(position, quaternion, scale);
 
       Local<Object> xrHitResult = Nan::New<Object>();
-      Local<Float32Array> hitMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), hitMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
+      Local<Float32Array> hitMatrixArray = Float32Array::New(ArrayBuffer::New(Isolate::GetCurrent(), (void *)hitMatrix.matrix_colmajor, 16 * sizeof(float)), 0, 16);
       xrHitResult->Set(JS_STR("hitMatrix"), hitMatrixArray);
       Local<Array> array = Nan::New<Array>(1);
       array->Set(0, xrHitResult);

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2693,7 +2693,7 @@ NAN_METHOD(MLContext::RequestHitTest) {
     MLHandle requestHandle;
     MLResult result = MLRaycastRequest(raycastTracker, &raycastQuery, &requestHandle);
     if (result == MLResult_Ok) {
-      MLRaycaster *raycaster = new MLRaycaster(cb);
+      MLRaycaster *raycaster = new MLRaycaster(requestHandle, cb);
       raycasters.push_back(raycaster);
     } else {
       ML_LOG(Error, "%s: Failed to request raycast: %x", application_name, result);

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2362,7 +2362,7 @@ NAN_METHOD(MLContext::Exit) {
     return;
   }
   
-  if (MLRaycastDestroy(&raycastTracker) != MLResult_Ok) {
+  if (MLRaycastDestroy(raycastTracker) != MLResult_Ok) {
     ML_LOG(Error, "%s: failed to destroy raycast handle", application_name);
     return;
   }

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2676,14 +2676,14 @@ NAN_METHOD(MLContext::RequestHitTest) {
     Local<Function> cb = Local<Function>::Cast(info[1]);
 
     raycastQuery.position = MLVec3f{
-      origin->Get(JS_STR("x"))->NumberValue(),
-      origin->Get(JS_STR("y"))->NumberValue(),
-      origin->Get(JS_STR("z"))->NumberValue(),
+      (float)origin->Get(JS_STR("x"))->NumberValue(),
+      (float)origin->Get(JS_STR("y"))->NumberValue(),
+      (float)origin->Get(JS_STR("z"))->NumberValue(),
     };
     raycastQuery.direction = MLVec3f{
-      direction->Get(JS_STR("x"))->NumberValue(),
-      direction->Get(JS_STR("y"))->NumberValue(),
-      direction->Get(JS_STR("z"))->NumberValue(),
+      (float)direction->Get(JS_STR("x"))->NumberValue(),
+      (float)direction->Get(JS_STR("y"))->NumberValue(),
+      (float)direction->Get(JS_STR("z"))->NumberValue(),
     };
     raycastQuery.up_vector = MLVec3f{0, 1, 0};
     raycastQuery.width = 1;

--- a/examples/audio.html
+++ b/examples/audio.html
@@ -81,7 +81,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           controllerMesh.updateMatrixWorld(true);
         }
       }

--- a/examples/browser.html
+++ b/examples/browser.html
@@ -302,7 +302,7 @@ function animate(timestamp, frame) {
     const inputSource = inputSources[i];
     const pose = frame.getInputPose(inputSource);
     const controllerMesh = controllerMeshes[i];
-    controllerMesh.matrix.fromArray(pose.pointerMatrix);
+    controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
     controllerMesh.matrix.decompose(controllerMesh.position, controllerMesh.quaternion, controllerMesh.scale);
     controllerMesh.updateMatrixWorld(true);
 

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -57,8 +57,9 @@ window._makeFakeDisplay = () => {
 
   fakeDisplay.update(); // initialize gamepads
   for (let i = 0; i < fakeDisplay.gamepads.length; i++) {
-    fakeDisplay.gamepads[i].pose.pointerMatrix = new Float32Array(16);
-    fakeDisplay.gamepads[i].pose._localPointerMatrix = new Float32Array(16);
+    fakeDisplay.gamepads[i].pose.targetRay = {
+      transformMatrix: new Float32Array(16),
+    };
   }
 
   const onends = [];

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -42,6 +42,15 @@ window._makeFakeDisplay = () => {
         fakeDisplay.quaternion.toArray(gamepad.pose.orientation);
       }
 
+      if (!gamepad.pose._localPointerMatrix) {
+        gamepad.pose._localPointerMatrix = new Float32Array(32);
+      }
+      if (!gamepad.pose.targetRay) {
+        gamepad.pose.targetRay = {
+          transformMatrix: new Float32Array(32),
+        };
+      }
+
       localMatrix2
         .compose(
           localVector.fromArray(gamepad.pose.position),

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -58,8 +58,6 @@ window._makeFakeDisplay = () => {
           localVector2.set(1, 1, 1)
         )
         .toArray(gamepad.pose._localPointerMatrix);
-       localMatrix2
-        .toArray(gamepad.pose.pointerMatrix);
     }
   };
 
@@ -153,12 +151,7 @@ window._makeFakeDisplay = () => {
         return this._pose;
       },
       getInputPose(inputSource, coordinateSystem) {
-        localMatrix
-          .compose(
-            localVector.fromArray(inputSource.pose.position),
-            localQuaternion.fromArray(inputSource.pose.orientation),
-            localVector2.set(1, 1, 1)
-          )
+        localMatrix.fromArray(inputSource.pose._localPointerMatrix);
 
         if (self.window) {
           const {xrOffset} = self.window.document;
@@ -173,10 +166,7 @@ window._makeFakeDisplay = () => {
             );
         }
 
-        localMatrix
-          .toArray(inputSource.pose._localPointerMatrix);
-        localMatrix
-          .toArray(inputSource.pose.pointerMatrix);
+        localMatrix.toArray(inputSource.pose.targetRay.transformMatrix);
 
         return inputSource.pose; // XXX or _pose
       },

--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -52,7 +52,6 @@ window._makeFakeDisplay = () => {
        localMatrix2
         .toArray(gamepad.pose.pointerMatrix);
     }
-    // console.log('gamepade pose', fakeDisplay.gamepads[1].pose.position);
   };
 
   fakeDisplay.update(); // initialize gamepads

--- a/examples/geometry_client.html
+++ b/examples/geometry_client.html
@@ -259,7 +259,7 @@ function animate(time, frame) {
     const pose = frame.getInputPose(inputSource);
 
     const controllerMesh = controllerMeshes[i];
-    controllerMesh.matrix.fromArray(pose.pointerMatrix);
+    controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
     controllerMesh.updateMatrixWorld(true);
   }
 
@@ -276,7 +276,7 @@ function animate(time, frame) {
       const inputSource = inputSources[paintControllerIndex];
       const pose = frame.getInputPose(inputSource);
 
-      localMatrix.fromArray(pose.pointerMatrix)
+      localMatrix.fromArray(pose.targetRay.transformMatrix)
         .decompose(localVector, localQuaternion, localVector2);
       localVector.sub(scene2.position);
     }
@@ -349,7 +349,7 @@ function animate(time, frame) {
         const inputSource = inputSources[controllerIndex];
         const pose = frame.getInputPose(inputSource);
 
-        localMatrix.fromArray(pose.pointerMatrix)
+        localMatrix.fromArray(pose.targetRay.transformMatrix)
           .decompose(localVector, localQuaternion, localVector2);
 
         _teleportStart(localVector, localQuaternion);
@@ -398,7 +398,7 @@ function animate(time, frame) {
     const rotation = localQuaternion.toArray();
     const controllers = inputSources.map(inputSource => {
       const pose = frame.getInputPose(inputSource);
-      localMatrix.fromArray(pose.pointerMatrix)
+      localMatrix.fromArray(pose.targetRay.transformMatrix)
         .decompose(localVector, localQuaternion, localVector2);
 
       return {

--- a/examples/geometry_ml.html
+++ b/examples/geometry_ml.html
@@ -698,7 +698,7 @@ function animate(time, frame) {
       const pose = frame.getInputPose(inputSource);
 
       const controllerMesh = controllerMeshes[i];
-      controllerMesh.matrix.fromArray(pose.pointerMatrix);
+      controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
       controllerMesh.updateMatrixWorld(true);
     }
 
@@ -706,7 +706,7 @@ function animate(time, frame) {
       const inputSource = inputSources[paintControllerIndex];
       const pose = frame.getInputPose(inputSource);
 
-      localMatrix.fromArray(pose.pointerMatrix)
+      localMatrix.fromArray(pose.targetRay.transformMatrix)
         .decompose(localVector, localQuaternion, localVector2);
       localVector.sub(scene2.position);
       paintMesh.update(localVector, localQuaternion);
@@ -775,7 +775,7 @@ function animate(time, frame) {
         const inputSource = inputSources[controllerIndex];
         const pose = frame.getInputPose(inputSource);
 
-        localMatrix.fromArray(pose.pointerMatrix)
+        localMatrix.fromArray(pose.targetRay.transformMatrix)
           .decompose(localVector, localQuaternion, localVector2);
 
         _teleportStart(localVector, localQuaternion);
@@ -828,7 +828,7 @@ function animate(time, frame) {
         const rotation = localQuaternion.toArray();
         const controllers = inputSources.map(inputSource => {
           const pose = frame.getInputPose(inputSource);
-          localMatrix.fromArray(pose.pointerMatrix)
+          localMatrix.fromArray(pose.targetRay.transformMatrix)
             .decompose(localVector, localQuaternion, localVector2);
 
           return {

--- a/examples/hands_ml.html
+++ b/examples/hands_ml.html
@@ -328,7 +328,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           controllerMesh.updateMatrixWorld(true);
         }
       } */

--- a/examples/hello_ml.html
+++ b/examples/hello_ml.html
@@ -429,7 +429,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           controllerMesh.updateMatrixWorld(true);
         }
       }

--- a/examples/imagetracking_ml.html
+++ b/examples/imagetracking_ml.html
@@ -190,7 +190,7 @@
         const inputSource = inputSources[0];
         const pose = frame.getInputPose(inputSource);
 
-        swordMesh.matrix.fromArray(pose.pointerMatrix);
+        swordMesh.matrix.fromArray(pose.targetRay.transformMatrix);
         swordMesh.matrix.decompose(swordMesh.position, swordMesh.quaternion, swordMesh.scale);
         swordMesh.updateMatrixWorld(true);
       }

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -305,7 +305,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           controllerMesh.updateMatrixWorld(true);
         }
       }

--- a/examples/microphone.html
+++ b/examples/microphone.html
@@ -146,7 +146,7 @@
             const pose = frame.getInputPose(inputSource);
 
             const controllerMesh = controllerMeshes[i];
-            controllerMesh.matrix.fromArray(pose.pointerMatrix);
+            controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
             controllerMesh.updateMatrixWorld(true);
           }
 

--- a/examples/minimap_ml.html
+++ b/examples/minimap_ml.html
@@ -352,7 +352,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           // controllerMesh.updateMatrixWorld();
           controllerMesh.matrixWorldNeedsUpdate = true;
           // controllerMesh.matrixWorld.multiplyMatrices(controllerMesh.parent.matrixWorld, controllerMesh.matrix);
@@ -363,18 +363,17 @@
           // console.log('controller position', controllerMesh.position.toArray().join(','));
 
           if (i === 0) { // left
-            intersectCamera.matrix.fromArray(pose.pointerMatrix);
+            intersectCamera.matrix.fromArray(pose.targetRay.transformMatrix);
             intersectCamera.matrix.decompose(intersectCamera.position, intersectCamera.quaternion, intersectCamera.scale);
             // console.log('position', intersectCamera.position.toArray().join(','));
             intersectCamera.updateMatrixWorld(true);
 
             if (planeMesh.visible) {
-              planeMesh.matrix.fromArray(pose.pointerMatrix);
-              planeMesh.matrixWorldNeedsUpdate = true;
-              // planeMesh.matrix.decompose(planeMesh.position, planeMesh.quaternion, planeMesh.scale);
-              // planeMesh.updateMatrixWorld(true);
+              planeMesh.matrix.fromArray(pose.targetRay.transformMatrix);
+              planeMesh.matrix.decompose(planeMesh.position, planeMesh.quaternion, planeMesh.scale);
+              planeMesh.updateMatrixWorld(true);
             } else {
-              containerMesh.matrix.fromArray(pose.pointerMatrix);
+              containerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
               containerMesh.matrix.decompose(containerMesh.position, containerMesh.quaternion, containerMesh.scale);
               containerMesh.position.y += 0.1;
               localEuler.setFromQuaternion(containerMesh.quaternion, 'YXZ');

--- a/examples/minimap_ml.html
+++ b/examples/minimap_ml.html
@@ -356,7 +356,7 @@
           // controllerMesh.updateMatrixWorld();
           controllerMesh.matrixWorldNeedsUpdate = true;
           // controllerMesh.matrixWorld.multiplyMatrices(controllerMesh.parent.matrixWorld, controllerMesh.matrix);
-          // controllerMesh.matrixWorld.fromArray(pose.pointerMatrix);
+          // controllerMesh.matrixWorld.fromArray(pose.targetRay.transformMatrix);
           // controllerMesh.matrix.decompose(controllerMesh.position, controllerMesh.quaternion, controllerMesh.scale);
           // controllerMesh.updateMatrixWorld(true);
 

--- a/examples/pathfinding_ml.html
+++ b/examples/pathfinding_ml.html
@@ -401,7 +401,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           controllerMesh.updateMatrixWorld(true);
         }
       } */

--- a/examples/planes_ml.html
+++ b/examples/planes_ml.html
@@ -284,7 +284,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           controllerMesh.updateMatrixWorld(true);
         }
       }

--- a/examples/radar_ml.html
+++ b/examples/radar_ml.html
@@ -209,7 +209,7 @@
           const pose = frame.getInputPose(inputSource);
 
           const controllerMesh = controllerMeshes[i];
-          controllerMesh.matrix.fromArray(pose.pointerMatrix);
+          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           controllerMesh.matrix.decompose(controllerMesh.position, controllerMesh.quaternion, controllerMesh.scale);
           controllerMesh.updateMatrixWorld(true);
 
@@ -232,7 +232,7 @@
         const inputSource = inputSources[0];
         const pose = frame.getInputPose(inputSource);
 
-        woodMesh.matrix.fromArray(pose.pointerMatrix);
+        woodMesh.matrix.fromArray(pose.targetRay.transformMatrix);
         woodMesh.matrix.decompose(woodMesh.position, woodMesh.quaternion, woodMesh.scale);
         woodMesh.updateMatrixWorld(true);
       } */

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -1140,11 +1140,13 @@ function animate(time, frame) {
       const pose = frame.getInputPose(inputSource);
       const {iframe} = tab;
 
-      localQuaternion.fromArray(pose.orientation);
+      localMatrix
+        .fromArray(pose.targetRay.transformMatrix)
+        .decompose(localVector, localQuaternion, localVector2);
+
       localVector
-        .fromArray(pose.position)
         .add(
-          localVector2.set(0, 0, -1)
+          localVector2.set(0, 0, -1.5)
             .applyQuaternion(localQuaternion)
         );
 

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -1121,15 +1121,12 @@ function animate(time, frame) {
 
         const inputSource = inputSources[i];
         const pose = frame.getInputPose(inputSource);
-        localMatrix2
-          .compose(
-            localVector.fromArray(gamepad.pose.position),
-            localQuaternion.fromArray(gamepad.pose.orientation),
-            localVector2.set(1, 1, 1)
-          )
-          .toArray(pose._localPointerMatrix);
-         localMatrix2
-          .toArray(pose.pointerMatrix);
+        localMatrix.compose(
+          localVector.fromArray(gamepad.pose.position),
+          localQuaternion.fromArray(gamepad.pose.orientation),
+          localVector2.set(1, 1, 1)
+        )
+          .toArray(pose.targetRay.transformMatrix);
       }
     }
   };
@@ -1164,7 +1161,7 @@ function animate(time, frame) {
         const inputSource = inputSources[i];
         const pose = frame.getInputPose(inputSource);
         const controllerMesh = controllerMeshes[i];
-        controllerMesh.matrix.fromArray(pose.pointerMatrix);
+        controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
         controllerMesh.matrix.decompose(controllerMesh.position, controllerMesh.quaternion, controllerMesh.scale);
         controllerMesh.updateMatrixWorld(true);
       }

--- a/examples/shooter_ml.html
+++ b/examples/shooter_ml.html
@@ -398,17 +398,17 @@
           const pose = frame.getInputPose(inputSource);
 
           const rayMesh = rayMeshes[i];
-          rayMesh.matrix.fromArray(pose.pointerMatrix);
+          rayMesh.matrix.fromArray(pose.targetRay.transformMatrix);
           rayMesh.matrix.decompose(localVector, localQuaternion, localVector2);
           rayMesh.updateMatrixWorld(true);
 
           if (i === 0) { // left
-            // intersectCamera.matrix.fromArray(pose.pointerMatrix);
+            // intersectCamera.matrix.fromArray(pose.targetRay.transformMatrix);
             // intersectCamera.matrix.decompose(intersectCamera.position, intersectCamera.quaternion, intersectCamera.scale);
             // console.log('position', intersectCamera.position.toArray().join(','));
             // intersectCamera.updateMatrixWorld(true);
 
-            planeMesh.matrix.fromArray(pose.pointerMatrix);
+            planeMesh.matrix.fromArray(pose.targetRay.transformMatrix);
             planeMesh.matrix.decompose(planeMesh.position, planeMesh.quaternion, planeMesh.scale);
             planeMesh.updateMatrixWorld(true);
           }

--- a/examples/sword_ml.html
+++ b/examples/sword_ml.html
@@ -91,7 +91,7 @@
         const inputSource = inputSources[0];
         const pose = frame.getInputPose(inputSource);
 
-        swordMesh.matrix.fromArray(pose.pointerMatrix);
+        swordMesh.matrix.fromArray(pose.targetRay.transformMatrix);
         swordMesh.matrix.decompose(swordMesh.position, swordMesh.quaternion, swordMesh.scale);
         swordMesh.updateMatrixWorld(true);
       }

--- a/src/XR.js
+++ b/src/XR.js
@@ -478,6 +478,15 @@ class XRInputSource {
 }
 module.exports.XRInputSource = XRInputSource;
 
+class XRRay {
+  constructor() {
+    this.origin = new GlobalContext.DOMPoint(0, 0, 0, 1);
+    this.direction = new GlobalContext.DOMPoint(0, 0, 1, 0);
+    this.transformMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+  }
+}
+module.exports.XRRay = XRRay;
+
 class XRInputPose {
   constructor() {
     this.emulatedPosition = false;

--- a/src/XR.js
+++ b/src/XR.js
@@ -120,6 +120,7 @@ class XRSession extends EventTarget {
     ];
     this._lastPresseds = [false, false];
     this._rafs = [];
+    this._onrequesthittest = null;
   }
   get layers() {
     return this.device.layers;
@@ -153,6 +154,17 @@ class XRSession extends EventTarget {
       }
       return result;
     }
+  }
+  requestHitTest(ray, coordinateSystem) {
+    return new Promise((accept, reject) => {
+      if (this._onrequesthittest)  {
+        this._onrequesthittest(ray, coordinateSystem, result => {
+          accept(result);
+        });
+      } else {
+        reject(new Error('api not supported'));
+      }
+    });
   }
   end() {
     this.emit('end');

--- a/src/XR.js
+++ b/src/XR.js
@@ -15,6 +15,7 @@ const _getFakeVrDisplay = window => {
 
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
+const localVector3 = new THREE.Vector3();
 const localQuaternion = new THREE.Quaternion();
 const localMatrix = new THREE.Matrix4();
 const localMatrix2 = new THREE.Matrix4();
@@ -217,17 +218,23 @@ class XRSession extends EventTarget {
       this._frameOfReference.emulatedHeight = stageParameters.position.y; // XXX
     } */
     if (gamepads !== undefined) {
-      const scale = localVector2.set(1, 1, 1);
+      const scale = localVector3.set(1, 1, 1);
 
       for (let i = 0; i < 2; i++) {
         const gamepad = gamepads[i];
         if (gamepad) {
           const inputSource = this._inputSources[i];
-          const inputMatrix = localMatrix.compose(
-            localVector.fromArray(gamepad.pose.position),
-            localQuaternion.fromArray(gamepad.pose.orientation),
-            scale
-          );
+          const position = localVector.fromArray(gamepad.pose.position);
+          const quaternion = localQuaternion.fromArray(gamepad.pose.orientation);
+          const direction = localVector2.set(0, 0, -1).applyQuaternion(quaternion);
+          const inputMatrix = localMatrix.compose(position, quaternion, scale);
+          inputSource._pose.targetRay.origin.x = position.x;
+          inputSource._pose.targetRay.origin.y = position.y;
+          inputSource._pose.targetRay.origin.z = position.z;
+          inputSource._pose.targetRay.direction.x = direction.x;
+          inputSource._pose.targetRay.direction.y = direction.y;
+          inputSource._pose.targetRay.direction.z = direction.z;
+          inputMatrix.toArray(inputSource._pose.targetRay.transformMatrix);
           inputMatrix.toArray(inputSource._pose._localPointerMatrix);
           inputMatrix.toArray(inputSource._pose.gripMatrix);
 
@@ -490,7 +497,7 @@ module.exports.XRRay = XRRay;
 class XRInputPose {
   constructor() {
     this.emulatedPosition = false;
-    this.pointerMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+    this.targetRay = new XRRay();
     this.gripMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
     this._localPointerMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
   }

--- a/src/XR.js
+++ b/src/XR.js
@@ -121,7 +121,6 @@ class XRSession extends EventTarget {
     ];
     this._lastPresseds = [false, false];
     this._rafs = [];
-    this._onrequesthittest = null;
   }
   get layers() {
     return this.device.layers;
@@ -158,8 +157,8 @@ class XRSession extends EventTarget {
   }
   requestHitTest(ray, coordinateSystem) {
     return new Promise((accept, reject) => {
-      if (this._onrequesthittest)  {
-        this._onrequesthittest(ray, coordinateSystem, result => {
+      if (this.device.onrequesthittest)  {
+        this.device.onrequesthittest(ray, coordinateSystem, result => {
           accept(result);
         });
       } else {

--- a/src/XR.js
+++ b/src/XR.js
@@ -393,7 +393,7 @@ class XRPresentationFrame {
       }
     }
 
-    localMatrix.toArray(inputSource._pose.pointerMatrix);
+    localMatrix.toArray(inputSource._pose.targetRay.transformMatrix);
     
     return inputSource._pose;
   }

--- a/src/core.js
+++ b/src/core.js
@@ -1717,7 +1717,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     _bindMRDisplay(mlDisplay);
     mlDisplay.onrequestpresent = layers => nativeMl.requestPresent(layers);
     mlDisplay.onexitpresent = () => nativeMl.exitPresent();
-    mlDisplay.onrequesthittest = nativeMl.requestHitTest;
+    mlDisplay.onrequesthittest = function() { return nativeMl.requestHitTest.apply(this, arguments); };
     mlDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };
@@ -1737,7 +1737,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
           return session;
         });
     })(xmDisplay.requestSession);
-    xmDisplay.onrequesthittest = nativeMl.requestHitTest;
+    xmDisplay.onrequesthittest = function() { return nativeMl.requestHitTest.apply(this, arguments); };
     xmDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };

--- a/src/core.js
+++ b/src/core.js
@@ -601,6 +601,16 @@ class FileReader extends EventTarget {
   }
 }
 
+class DOMPoint {
+  constructor(x = 0, y = 0, z = 0, w = 1) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.w = w;
+  }
+}
+GlobalContext.DOMPoint = DOMPoint;
+
 const _fromAST = (node, window, parentNode, ownerDocument, uppercase) => {
   if (node.nodeName === '#text') {
     const text = new DOM.Text(node.value);
@@ -1446,6 +1456,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.FakeVRDisplay = FakeVRDisplay;
   // window.ARDisplay = ARDisplay;
   window.VRFrameData = VRFrameData;
+  window.DOMPoint = DOMPoint;
   if (window.navigator.xr) {
     window.XR = XR.XR;
     window.XRDevice = XR.XRDevice;

--- a/src/core.js
+++ b/src/core.js
@@ -1467,6 +1467,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     window.XRViewport = XR.XRViewport;
     window.XRDevicePose = XR.XRDevicePose;
     window.XRInputSource = XR.XRInputSource;
+    window.XRRay = XR.XRRay;
     window.XRInputPose = XR.XRInputPose;
     window.XRInputSourceEvent = XR.XRInputSourceEvent;
     window.XRCoordinateSystem = XR.XRCoordinateSystem;

--- a/src/core.js
+++ b/src/core.js
@@ -1717,6 +1717,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     _bindMRDisplay(mlDisplay);
     mlDisplay.onrequestpresent = layers => nativeMl.requestPresent(layers);
     mlDisplay.onexitpresent = () => nativeMl.exitPresent();
+    mlDisplay.onrequesthittest = nativeMl.requestHitTest;
     mlDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };
@@ -1736,6 +1737,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
           return session;
         });
     })(xmDisplay.requestSession);
+    xmDisplay.onrequesthittest = nativeMl.requestHitTest;
     xmDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };


### PR DESCRIPTION
This updates the WebXR implementation to use [XRRay](https://immersive-web.github.io/webxr/#xrray-interface) where specced, which unlocks the `XRSession.requestHitTest()` API for use.

Implemented via meshing on Magic Leap.