### PR TITLE
Add --download support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-build
+/build
 package-lock.json
 CMakeFiles
 CMakeCache.txt

--- a/deps/exokit-bindings/canvascontext/src/canvas-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/canvas-context.cc
@@ -97,7 +97,7 @@ Handle<Object> CanvasRenderingContext2D::Initialize(Isolate *isolate, Local<Valu
   
   Nan::SetMethod(proto, "setTexture", ctxCallWrap<SetTexture>);
 
-  Nan::SetMethod(proto, "destroy", ctxCallWrap<Destroy>);
+  Nan::SetMethod(proto, "destroy", Destroy);
   Nan::SetMethod(proto, "getWindowHandle", GetWindowHandle);
   Nan::SetMethod(proto, "setWindowHandle", SetWindowHandle);
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -2189,7 +2189,9 @@ class HTMLCanvasElement extends HTMLElement {
         this._context = null;
       }
       if (this._context === null) {
-        if (GlobalContext.args.webgl === '1') {
+        const window = this.ownerDocument.defaultView;
+
+        if (window[symbols.optionsSymbol].args.webgl === '1') {
           if (contextType === 'webgl' || contextType === 'xrpresent') {
             this._context = new GlobalContext.WebGLRenderingContext(this);
           }

--- a/src/Document.js
+++ b/src/Document.js
@@ -197,7 +197,7 @@ function initDocument (document, window) {
     window.dispatchEvent(new Event('load', {target: window}));
 
     const displays = window.navigator.getVRDisplaysSync();
-    if (displays.length > 0 && ['all', 'webvr', 'webxr'].includes(GlobalContext.args.xr)) {
+    if (displays.length > 0 && ['all', 'webvr', 'webxr'].includes(window[symbols.optionsSymbol].args.xr)) {
       const _initDisplays = () => {
         if (!_tryEmitDisplay()) {
           _delayFrames(() => {

--- a/src/core.js
+++ b/src/core.js
@@ -1117,7 +1117,17 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         return super.open(method, url, async, username, password);
       }
       get response() {
-        return utils._normalizePrototype(super.response, window);
+        const _maybeDownload = (GlobalContext.args.download && this._properties.method === 'GET') ? _download : (u, data, bufferifyFn) => Promise.resolve(data);
+        
+        return _maybeDownload(this._properties.uri, utils._normalizePrototype(super.response, window), o => {
+          switch (this.responseType) {
+            case 'arraybuffer': return Buffer.from(o);
+            case 'blob': return o.buffer;
+            case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
+            case 'json': return Buffer.from(o, 'utf8');
+            default: throw new Error(`cannot download responseType ${responseType}`);
+          }
+        });
       }
     }
     for (const k in XMLHttpRequestBase) {

--- a/src/core.js
+++ b/src/core.js
@@ -1012,48 +1012,76 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       intervals[index] = null;
     }
   };
-  window.fetch = (url, options) => {
-    const _boundFetch = (url, options) => utils._normalizePrototype(
-      fetch(url, options),
-      window
-    )
-      .then(res => {
-        res.arrayBuffer = (fn => function() {
-          return utils._normalizePrototype(
-            fn.apply(this, arguments),
-            window
-          );
-        })(res.arrayBuffer);
-        res.blob = (fn => function() {
-          return utils._normalizePrototype(
-            fn.apply(this, arguments),
-            window
-          );
-        })(res.blob);
-        res.json = (fn => function() {
-          return utils._normalizePrototype(
-            fn.apply(this, arguments),
-            window
-          );
-        })(res.json);
-        res.text = (fn => function() {
-          return utils._normalizePrototype(
-            fn.apply(this, arguments),
-            window
-          );
-        })(res.text);
+  window.fetch = (u, options) => {
+    const _boundFetch = (u, options) => {
+      const req = utils._normalizePrototype(
+        fetch(u, options),
+        window
+      );
+      return req
+        .then(res => {
+          res.arrayBuffer = (fn => function() {
+            return utils._normalizePrototype(
+              fn.apply(this, arguments),
+              window
+            );
+          })(res.arrayBuffer);
+          res.blob = (fn => function() {
+            return utils._normalizePrototype(
+              fn.apply(this, arguments),
+              window
+            );
+          })(res.blob);
+          res.json = (fn => function() {
+            return utils._normalizePrototype(
+              fn.apply(this, arguments),
+              window
+            );
+          })(res.json);
+          res.text = (fn => function() {
+            return utils._normalizePrototype(
+              fn.apply(this, arguments),
+              window
+            );
+          })(res.text);
 
-        res.arrayBuffer = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(ab => utils._normalizePrototype(ab, window));
-        })(res.arrayBuffer);
-        res.blob = (fn => function() {
-          return fn.apply(this, arguments)
-            .then(b => utils._normalizePrototype(b, window));
-        })(res.blob);
+          const _maybeDownload = (GlobalContext.args.download && req.method === 'GET') ? (data, bufferifyFn) => new Promise((accept, reject) => {
+            if (/^(?:https?|file):/.test(u)) {
+              let p = path.join(GlobalContext.args.download, p.host || '.');
+              if (url.parse(u).path === '/') {
+                p = path.join(p, 'index.html');
+              }
+              fs.writeFile(p, bufferifyFn(data), err => {
+                if (!err) {
+                  accept(data);
+                } else {
+                  reject(err);
+                }
+              });
+            } else {
+              accept(data);
+            }
+          }) : (data, bufferifyFn) => Promise.resolve(data);
+          res.arrayBuffer = (fn => function() {
+            return fn.apply(this, arguments)
+              .then(ab => _maybeDownload(utils._normalizePrototype(ab, window), ab => Buffer.from(ab)));
+          })(res.arrayBuffer);
+          res.blob = (fn => function() {
+            return fn.apply(this, arguments)
+              .then(blob => _maybeDownload(utils._normalizePrototype(blob, window), blob => blob.buffer);
+          })(res.blob);
+          res.json = (fn => function() {
+            return fn.apply(this, arguments)
+              .then(j => _maybeDownload(j, j => Buffer.from(JSON.stringify(j))));
+          })(res.json);
+          res.text = (fn => function() {
+            return fn.apply(this, arguments)
+              .then(t => _maybeDownload(t, t => Buffer.from(t, 'utf8')));
+          })(res.text);
 
-        return res;
-      });
+          return res;
+        });
+    };
 
     if (typeof url === 'string') {
       const blob = urls.get(url);

--- a/src/core.js
+++ b/src/core.js
@@ -1083,17 +1083,16 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         });
     };
 
-    if (typeof url === 'string') {
-      const blob = urls.get(url);
+    if (typeof u === 'string') {
+      const blob = urls.get(u);
       if (blob) {
         return Promise.resolve(new Response(blob));
       } else {
-        const oldUrl = url;
-        url = _normalizeUrl(url);
-        return _boundFetch(url, options);
+        u = _normalizeUrl(u);
+        return _boundFetch(u, options);
       }
     } else {
-      return _boundFetch(url, options);
+      return _boundFetch(u, options);
     }
   };
   window.Request = Request;

--- a/src/core.js
+++ b/src/core.js
@@ -1019,7 +1019,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   const _maybeDownload = (m, u, data, bufferifyFn) => GlobalContext.args.download ? new Promise((accept, reject) => {
     if (m === 'GET' && /^(?:https?|file):/.test(u)) {
       const o = url.parse(u);
-      const d = path.join(GlobalContext.args.download, o.host || '.');
+      const d = path.resolve(path.join(__dirname, '..'), GlobalContext.args.download, o.host || '.');
       const f = path.join(d, o.pathname === '/' ? 'index.html' : o.pathname);
 
       const dirname = path.dirname(f);

--- a/src/core.js
+++ b/src/core.js
@@ -998,14 +998,14 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   };
 
   // WebVR enabled.
-  if (['all', 'webvr'].includes(options.args.xr)) {
+  if (options.args && ['all', 'webvr'].includes(options.args.xr)) {
     window.navigator.getVRDisplays = function() {
       return Promise.resolve(this.getVRDisplaysSync());
     }
   }
 
   // WebXR enabled.
-  if (['all', 'webxr'].includes(options.args.xr)) {
+  if (options.args && ['all', 'webxr'].includes(options.args.xr)) {
     window.navigator.xr = new XR.XR(window);
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -1425,7 +1425,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.CanvasGradient = CanvasGradient;
   window.CanvasRenderingContext2D = CanvasRenderingContext2D;
   window.WebGLRenderingContext = WebGLRenderingContext;
-  if (options.args.webgl !== '1') {
+  if (options.args && options.args.webgl !== '1') {
     window.WebGL2RenderingContext = WebGL2RenderingContext;
   }
   window.Audio = HTMLAudioElementBound;

--- a/src/core.js
+++ b/src/core.js
@@ -797,6 +797,31 @@ const _cloneMrDisplays = (mrDisplays, window) => {
   return result;
 };
 
+const _download = (m, u, data, bufferifyFn, dstDir) => new Promise((accept, reject) => {
+  if (m === 'GET' && /^(?:https?|file):/.test(u)) {
+    const o = url.parse(u);
+    const d = path.resolve(path.join(__dirname, '..'), dstDir, o.host || '.');
+    const f = path.join(d, o.pathname === '/' ? 'index.html' : o.pathname);
+
+    console.log(`${u} -> ${f}`);
+
+    mkdirp(path.dirname(f), err => {
+      if (!err) {
+        fs.writeFile(f, bufferifyFn(data), err => {
+          if (!err) {
+            accept(data);
+          } else {
+            reject(err);
+          }
+        });
+      } else {
+        reject(err);
+      }
+    });
+  } else {
+    accept(data);
+  }
+});
 const _makeWindow = (options = {}, parent = null, top = null) => {
   const _normalizeUrl = utils._makeNormalizeUrl(options.baseUrl);
 
@@ -1024,31 +1049,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       intervals[index] = null;
     }
   };
-  const _maybeDownload = (m, u, data, bufferifyFn) => options.args.download ? new Promise((accept, reject) => {
-    if (m === 'GET' && /^(?:https?|file):/.test(u)) {
-      const o = url.parse(u);
-      const d = path.resolve(path.join(__dirname, '..'), options.args.download, o.host || '.');
-      const f = path.join(d, o.pathname === '/' ? 'index.html' : o.pathname);
-
-      console.log(`${u} -> ${f}`);
-
-      mkdirp(path.dirname(f), err => {
-        if (!err) {
-          fs.writeFile(f, bufferifyFn(data), err => {
-            if (!err) {
-              accept(data);
-            } else {
-              reject(err);
-            }
-          });
-        } else {
-          reject(err);
-        }
-      });
-    } else {
-      accept(data);
-    }
-  }) : data;
+  const _maybeDownload = (m, u, data, bufferifyFn) => options.args.download ? _download(m, u, data, bufferifyFn, options.args.download) : data;
   window.fetch = (u, options) => {
     const _boundFetch = (u, options) => {
       const req = utils._normalizePrototype(
@@ -1829,6 +1830,13 @@ exokit.load = (src, options = {}) => {
     .then(res => {
       if (res.status >= 200 && res.status < 300) {
         return res.text()
+          .then(t => {
+            if (options.args.download) {
+              return _download('GET', src, t, t => Buffer.from(t, 'utf8'), options.args.download);
+            } else {
+              return Promise.resolve(t);
+            }
+          })
           .then(htmlString => ({
             src,
             htmlString,

--- a/src/core.js
+++ b/src/core.js
@@ -1068,7 +1068,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
           })(res.arrayBuffer);
           res.blob = (fn => function() {
             return fn.apply(this, arguments)
-              .then(blob => _maybeDownload(req.method, u, utils._normalizePrototype(blob, window), blob => blob.buffer);
+              .then(blob => _maybeDownload(req.method, u, utils._normalizePrototype(blob, window), blob => blob.buffer));
           })(res.blob);
           res.json = (fn => function() {
             return fn.apply(this, arguments)

--- a/src/core.js
+++ b/src/core.js
@@ -180,6 +180,15 @@ class Resources extends EventTarget {
         });
       
       this.numRunning++;
+    } else {
+      const _isDone = () => this.numRunning === 0 && this.queue.length === 0;
+      if (_isDone()) {
+        process.nextTick(() => { // wait one tick for more resources before emitting drain
+          if (_isDone()) {
+            this.emit('drain');
+          }
+        });
+      }
     }
   }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -1862,12 +1862,15 @@ exokit.load = (src, options = {}) => {
         url: options.url || src,
         baseUrl,
         dataPath: options.dataPath,
+        args: options.args,
       });
     });
 };
 exokit.download = (src, dst) => exokit.load(src, {
-  download: dst,
-  headless: true,
+  args: {
+    download: dst,
+    headless: true,
+  },
 })
   .then(window => new Promise((accept, reject) => {
     window.document.resources.addEventListener('drain', () => {

--- a/src/core.js
+++ b/src/core.js
@@ -1121,7 +1121,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
             case 'arraybuffer': return Buffer.from(o);
             case 'blob': return o.buffer;
             case 'json': return Buffer.from(JSON.stringify(o), 'utf8');
-            case 'json': return Buffer.from(o, 'utf8');
+            case 'text': return Buffer.from(o, 'utf8');
             default: throw new Error(`cannot download responseType ${responseType}`);
           }
         });

--- a/src/core.js
+++ b/src/core.js
@@ -868,7 +868,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   utils._storeOriginalWindowPrototypes(window, symbols.prototypesSymbol);
 
   const windowStartScript = `(() => {
-    ${!GlobalContext.args.require ? 'global.require = undefined;' : ''}
+    ${!options.args.require ? 'global.require = undefined;' : ''}
 
     const _logStack = err => {
       console.warn(err);
@@ -973,14 +973,14 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   };
 
   // WebVR enabled.
-  if (['all', 'webvr'].includes(GlobalContext.args.xr)) {
+  if (['all', 'webvr'].includes(options.args.xr)) {
     window.navigator.getVRDisplays = function() {
       return Promise.resolve(this.getVRDisplaysSync());
     }
   }
 
   // WebXR enabled.
-  if (['all', 'webxr'].includes(GlobalContext.args.xr)) {
+  if (['all', 'webxr'].includes(options.args.xr)) {
     window.navigator.xr = new XR.XR(window);
   }
 
@@ -1024,10 +1024,10 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       intervals[index] = null;
     }
   };
-  const _maybeDownload = (m, u, data, bufferifyFn) => GlobalContext.args.download ? new Promise((accept, reject) => {
+  const _maybeDownload = (m, u, data, bufferifyFn) => options.args.download ? new Promise((accept, reject) => {
     if (m === 'GET' && /^(?:https?|file):/.test(u)) {
       const o = url.parse(u);
-      const d = path.resolve(path.join(__dirname, '..'), GlobalContext.args.download, o.host || '.');
+      const d = path.resolve(path.join(__dirname, '..'), options.args.download, o.host || '.');
       const f = path.join(d, o.pathname === '/' ? 'index.html' : o.pathname);
 
       console.log(`${u} -> ${f}`);
@@ -1424,7 +1424,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.CanvasGradient = CanvasGradient;
   window.CanvasRenderingContext2D = CanvasRenderingContext2D;
   window.WebGLRenderingContext = WebGLRenderingContext;
-  if (GlobalContext.args.webgl !== '1') {
+  if (options.args.webgl !== '1') {
     window.WebGL2RenderingContext = WebGL2RenderingContext;
   }
   window.Audio = HTMLAudioElementBound;
@@ -1815,6 +1815,7 @@ const exokit = (s = '', options = {}) => {
   options.url = options.url || 'http://127.0.0.1/';
   options.baseUrl = options.baseUrl || options.url;
   options.dataPath = options.dataPath || __dirname;
+  options.args = options.args || {};
   return _makeWindowWithDocument(s, options);
 };
 exokit.load = (src, options = {}) => {

--- a/src/core.js
+++ b/src/core.js
@@ -1831,7 +1831,7 @@ exokit.load = (src, options = {}) => {
       if (res.status >= 200 && res.status < 300) {
         return res.text()
           .then(t => {
-            if (options.args.download) {
+            if (options.args && options.args.download) {
               return _download('GET', src, t, t => Buffer.from(t, 'utf8'), options.args.download);
             } else {
               return Promise.resolve(t);

--- a/src/core.js
+++ b/src/core.js
@@ -1865,6 +1865,15 @@ exokit.load = (src, options = {}) => {
       });
     });
 };
+exokit.download = (src, dst) => exokit.load(src, {
+  download: dst,
+  headless: true,
+})
+  .then(window => new Promise((accept, reject) => {
+    window.document.resources.addEventListener('drain', () => {
+      accept();
+    });
+  }));
 exokit.getAllGamepads = getAllGamepads;
 exokit.THREE = THREE;
 exokit.setArgs = newArgs => {

--- a/src/core.js
+++ b/src/core.js
@@ -868,7 +868,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   utils._storeOriginalWindowPrototypes(window, symbols.prototypesSymbol);
 
   const windowStartScript = `(() => {
-    ${!options.args.require ? 'global.require = undefined;' : ''}
+    ${!(options.args && options.args.require) ? 'global.require = undefined;' : ''}
 
     const _logStack = err => {
       console.warn(err);

--- a/src/core.js
+++ b/src/core.js
@@ -1037,7 +1037,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     } else {
       accept(data);
     }
-  }) : (m, u, data, bufferifyFn) => data;
+  }) : data;
   window.fetch = (u, options) => {
     const _boundFetch = (u, options) => {
       const req = utils._normalizePrototype(

--- a/src/core.js
+++ b/src/core.js
@@ -11,6 +11,7 @@ const util = require('util');
 const {URL} = url;
 const {performance} = require('perf_hooks');
 
+const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
 
 const {XMLHttpRequest: XMLHttpRequestBase, FormData} = require('window-xhr');
@@ -1021,11 +1022,18 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       const d = path.join(GlobalContext.args.download, o.host || '.');
       const f = path.join(d, o.pathname === '/' ? 'index.html' : o.pathname);
 
-      mkdirp(path.dirname(f), err => {
+      const dirname = path.dirname(f);
+      rimraf(dirname, err => {
         if (!err) {
-          fs.writeFile(f, bufferifyFn(data), err => {
+          mkdirp(dirname, err => {
             if (!err) {
-              accept(data);
+              fs.writeFile(f, bufferifyFn(data), err => {
+                if (!err) {
+                  accept(data);
+                } else {
+                  reject(err);
+                }
+              });
             } else {
               reject(err);
             }

--- a/src/core.js
+++ b/src/core.js
@@ -11,7 +11,6 @@ const util = require('util');
 const {URL} = url;
 const {performance} = require('perf_hooks');
 
-const rimraf = require('rimraf');
 const mkdirp = require('mkdirp');
 
 const {XMLHttpRequest: XMLHttpRequestBase, FormData} = require('window-xhr');
@@ -1022,18 +1021,13 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       const d = path.resolve(path.join(__dirname, '..'), GlobalContext.args.download, o.host || '.');
       const f = path.join(d, o.pathname === '/' ? 'index.html' : o.pathname);
 
-      const dirname = path.dirname(f);
-      rimraf(dirname, err => {
+      console.log(`${u} -> ${f}`);
+
+      mkdirp(path.dirname(f), err => {
         if (!err) {
-          mkdirp(dirname, err => {
+          fs.writeFile(f, bufferifyFn(data), err => {
             if (!err) {
-              fs.writeFile(f, bufferifyFn(data), err => {
-                if (!err) {
-                  accept(data);
-                } else {
-                  reject(err);
-                }
-              });
+              accept(data);
             } else {
               reject(err);
             }

--- a/src/index.js
+++ b/src/index.js
@@ -1007,6 +1007,12 @@ const _bindWindow = (window, newWindowCb) => {
       }
     }
   });
+  if (args.download) {
+    window.document.resources.addEventListener('drain', () => {
+      console.log('drain');
+      process.exit();
+    });
+  }
   window.addEventListener('destroy', e => {
     const {window} = e;
     for (let i = 0; i < contexts.length; i++) {

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ const args = (() => {
         'xr',
         'size',
         'image',
+        'download',
       ],
       alias: {
         v: 'version',
@@ -68,6 +69,7 @@ const args = (() => {
         i: 'image',
         r: 'require',
         n: 'headless',
+        d: 'download',
       },
     });
     return {

--- a/src/index.js
+++ b/src/index.js
@@ -1765,6 +1765,7 @@ const _start = () => {
     }
     return core.load(u, {
       dataPath,
+      args,
     })
       .then(window => {
         if (args.image) {

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ const args = (() => {
       image: minimistArgs.image,
       require: minimistArgs.require,
       headless: minimistArgs.headless,
+      download: minimistArgs.download,
     };
   } else {
     return {};

--- a/src/index.js
+++ b/src/index.js
@@ -1007,7 +1007,7 @@ const _bindWindow = (window, newWindowCb) => {
       }
     }
   });
-  if (args.download) {
+  if (args.quit) {
     window.document.resources.addEventListener('drain', () => {
       console.log('drain');
       process.exit();
@@ -1848,9 +1848,6 @@ const _start = () => {
 
       callback(err, result);
     };
-    if (args.quit) {
-      process.exit();
-    }
     const r = repl.start({
       prompt,
       eval: replEval,

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
 
   const {nativeWindow} = nativeBindings;
   const windowSpec = (() => {
-    if (!args.headless) {
+    if (!window[symbols.optionsSymbol].args.headless) {
       try {
         const visible = !args.image && document.documentElement.contains(canvas);
         const {hidden} = document;
@@ -277,9 +277,11 @@ nativeBindings.nativeCanvasRenderingContext2D.onconstruct = (ctx, canvas) => {
 
   ctx.canvas = canvas;
 
+  const window = canvas.ownerDocument.defaultView;
+
   const {nativeWindow} = nativeBindings;
   const windowSpec = (() => {
-    if (!args.headless) {
+    if (!window[symbols.optionsSymbol].args.headless) {
       try {
         const firstWindowHandle = contexts.length > 0 ? contexts[0].getWindowHandle() : null;
         return nativeWindow.create2d(canvasWidth, canvasHeight, firstWindowHandle);


### PR DESCRIPTION
This adds site download support to Exokit. With the `--download <directory>` option, Exokit will dynamically save all `GET`s it downloads via `fetch`/`XHR`. This isn't a static download like wget -- it actually executes the Javascript.

This is useful for packaging support https://github.com/webmixedreality/exokit/pull/612 so we can get all site resources for a URL.

This is basically another take on `--mirror` (https://github.com/webmixedreality/exokit/pull/622).