### PR TITLE
FormData blob support

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "window-selector": "0.0.6",
     "window-text-encoding": "0.0.2",
     "window-worker": "0.0.98",
-    "window-xhr": "0.0.22",
+    "window-xhr": "0.0.23",
     "ws": "^6.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "window-selector": "0.0.6",
     "window-text-encoding": "0.0.2",
     "window-worker": "0.0.98",
-    "window-xhr": "0.0.21",
+    "window-xhr": "0.0.22",
     "ws": "^6.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "window-selector": "0.0.6",
     "window-text-encoding": "0.0.2",
     "window-worker": "0.0.98",
-    "window-xhr": "0.0.20",
+    "window-xhr": "0.0.21",
     "ws": "^6.1.2"
   },
   "devDependencies": {

--- a/src/core.js
+++ b/src/core.js
@@ -1140,7 +1140,11 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       super(parts && parts.map(part => utils._normalizePrototype(part, global)), opts);
     }
   })(Blob);
-  window.FormData = FormData;
+  window.FormData = (Old => class FormData extends Old {
+    append(field, value, options) {
+      super.append(field, utils._normalizePrototype(value, global), options);
+    }
+  })(window.FormData);
   window.XMLHttpRequest = (Old => {
     class XMLHttpRequest extends Old {
       open(method, url, async, username, password) {

--- a/src/core.js
+++ b/src/core.js
@@ -1144,7 +1144,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     append(field, value, options) {
       super.append(field, utils._normalizePrototype(value, global), options);
     }
-  })(window.FormData);
+  })(FormData);
   window.XMLHttpRequest = (Old => {
     class XMLHttpRequest extends Old {
       open(method, url, async, username, password) {


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/627.

Adds `Blob` support to FormData by forking, and ensures global prototype normalization for `FormData.prototype.append`.