### PR TITLE
Revert "Set document.ownerDocument = null"

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -37,7 +37,6 @@ function initDocument (document, window) {
   document.body = body;
   document.location = window.location;
   document.cookie = '';
-  document.ownerDocument = null;
   document.createElement = tagName => {
     tagName = tagName.toUpperCase();
     const HTMLElementTemplate = window[symbols.htmlTagsSymbol][tagName];


### PR DESCRIPTION
This reverts commit 57cc607bc1e612d0a33221b6d867aea8e2e6bda2.

This was causing `<script>` tags to fail to load, most likely due to bad event propagation.

Test failures: https://travis-ci.org/webmixedreality/exokit/builds/463446095