### PR TITLE
Refactor shared libraries load

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-const cwd = process.cwd();
-process.chdir(__dirname); // needed for global bin to find libraries
-
 const events = require('events');
 const {EventEmitter} = events;
 const path = require('path');

--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -1,5 +1,13 @@
 const path = require('path');
-const exokitNode = require(path.join(__dirname, '..', 'build', 'Release', 'exokit.node'));
+
+const exokitNode = (() => {
+  const oldCwd = process.cwd();
+  const nodeModulesDir = path.resolve(path.dirname(require.resolve('native-graphics-deps')), '..');
+  process.chdir(nodeModulesDir);
+  const exokitNode = require(path.join(__dirname, '..', 'build', 'Release', 'exokit.node'));
+  process.chdir(oldCwd);
+  return exokitNode;
+})();
 const {nativeAudio, nativeVr} = exokitNode;
 const WindowWorker = require('window-worker');
 const vmOne = require('vm-one');


### PR DESCRIPTION
Exokit uses shared libraries for native bindings. What triggers the load is loading the main `exokit.node` native module. Shared libraries are resolved via the Linux `rpath` mechanism.

The problem is that since the rpath is relative, we need to be in the right directory for the shared libraries in `node_modules` to be picked up.

This works well if we run from the exokit root and we installed in `node_modules` in the exokit root. but other scenarios, like installing an embedded `exokit` from npm, might have the `node_modules` flattened below `exokit` in the file heirarchy.

That is why we've hacked around the problem via `process.chdir` in `index.js`, but embedders do not want or expect this. Ideally requiring exokit does not change the current directory.

This refactors the `index.js` `process.chdir` hack to instead temporarily switch to the dynamically detected `node_modules` directory that contains the modules we are interested in (testing for `native-graphics-deps`).