### PR TITLE
Magic Leap WaitGetPoses missing SetCurrentWindowContext

### DIFF
--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2010,6 +2010,8 @@ NAN_METHOD(MLContext::WaitGetPoses) {
     if (application_context.dummy_value == DummyValue::RUNNING) {
       MLContext *mlContext = ObjectWrap::Unwrap<MLContext>(info.This());
       WebGLRenderingContext *gl = ObjectWrap::Unwrap<WebGLRenderingContext>(Local<Object>::Cast(info[0]));
+      
+      windowsystem::SetCurrentWindowContext(gl->windowHandle);
 
       GLuint framebuffer = info[1]->Uint32Value();
       GLuint width = info[2]->Uint32Value();


### PR DESCRIPTION
The bug here was that if you made calls to something that switches the GL context on your user thread (such as 3d or 2d `canvas`), especially outside of `requestAnimationFrame`, then the Magic Leap `WaitGetPoses` (which does GL environment things like drawing depthtest bufferr) would clobber things in your user context.

The result was things like undefined or missing textures. This fixes the problem by ensuring we are in the right GL context when we start `WaitGetPoses`. This was already optimized to not do any switch unless it's needed, so there is no performance hit.