### PR TITLE
Bump node dependencies to 10.14.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ matrix:
     - brew install glfw glew
     install:
     - npm install -g appdmg
-    - curl "https://nodejs.org/dist/v10.6.0/node-v10.6.0-darwin-x64.tar.gz" >node.tar.gz
+    - curl "https://nodejs.org/dist/v10.14.2/node-v10.14.2-darwin-x64.tar.gz" >node.tar.gz
     - tar -zxf node.tar.gz
     - rm node.tar.gz
-    - mv node-v10.6.0-darwin-x64 node
+    - mv node-v10.14.2-darwin-x64 node
     - export PATH="$(pwd)/node/bin:$PATH"
     - unset NVM_NODEJS_ORG_MIRROR
     - "./node/bin/npm install"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ ADD . /app
 WORKDIR /app
 
 RUN \
-  wget "https://nodejs.org/dist/v10.6.0/node-v10.6.0-linux-x64.tar.gz" -O node.tar.gz && \
+  wget "https://nodejs.org/dist/v10.14.2/node-v10.6.0-linux-x64.tar.gz" -O node.tar.gz && \
   tar -zxf node.tar.gz && \
   rm node.tar.gz && \
-  mv node-v10.6.0-linux-x64 node
+  mv node-v10.14.2-linux-x64 node
 RUN \
   export PATH="$PATH:$(pwd)/node/bin" && \
   npm install --unsafe-perm . && \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,10 @@ test_script:
 
 after_test:
   - ps: |
-      wget "https://nodejs.org/dist/v10.6.0/node-v10.6.0-win-x64.zip" -OutFile node.zip
+      wget "https://nodejs.org/dist/v10.14.2/node-v10.6.0-win-x64.zip" -OutFile node.zip
       7z x node.zip
       rm node.zip
-      mv node-v10.6.0-win-x64 node
+      mv node-v10.14.2-win-x64 node
       $env:Path = "$pwd\node;$env:Path";
       .\node\npm install
       .\node\npm run test:ci

--- a/metadata/program-device.mabu
+++ b/metadata/program-device.mabu
@@ -19,7 +19,7 @@ SRCS = ../main.cpp
 
 # Include paths for any language are specified here.
 #
-INCS = ../.node-gyp/10.9.0/include/node \
+INCS = ../.node-gyp/10.14.2/include/node \
   ../node_modules/nan
 
 # Macro definitions for any language are specified here.


### PR DESCRIPTION
This bumps all OS node dependencies to version 10.14.2. There should be no user-facing functionality change.