### PR TITLE
Fix reality tabs wrong baseLayer

### DIFF
--- a/src/XR.js
+++ b/src/XR.js
@@ -246,6 +246,7 @@ class XRSession extends EventTarget {
     for (const k in this) {
       o[k] = this[k];
     }
+    o.baseLayer = null;
     o._frame = o._frame.clone();
     o._frame.session = o;
     return o;

--- a/src/XR.js
+++ b/src/XR.js
@@ -330,7 +330,6 @@ class XRWebGLLayer {
         tex: 0,
         depthTex: 0,
       };
-    console.log('construct xrwebgllayer', presentSpec, new Error().stack);
     const {width, height, msFbo} = presentSpec;
 
     this.framebuffer = msFbo !== null ? {

--- a/src/XR.js
+++ b/src/XR.js
@@ -330,6 +330,7 @@ class XRWebGLLayer {
         tex: 0,
         depthTex: 0,
       };
+    console.log('construct xrwebgllayer', presentSpec, new Error().stack);
     const {width, height, msFbo} = presentSpec;
 
     this.framebuffer = msFbo !== null ? {

--- a/src/index.js
+++ b/src/index.js
@@ -413,10 +413,14 @@ if (nativeBindings.nativeVr) {
         vrPresentState.lmContext = lmContext;
 
         canvas.framebuffer = {
+          width,
+          height,
+          msFbo,
           msTex,
           msDepthTex,
-          tex: 0,
-          depthTex: 0,
+          fbo,
+          tex,
+          depthTex,
         };
 
         const _attribute = (name, value) => {
@@ -554,8 +558,12 @@ if (nativeBindings.nativeMl) {
           mlPresentState.mlMsDepthTex = msDepthTex;
 
           canvas.framebuffer = {
+            width,
+            height,
+            msFbo,
             msTex,
             msDepthTex,
+            fbo,
             tex,
             depthTex,
           };

--- a/src/index.js
+++ b/src/index.js
@@ -442,6 +442,10 @@ if (nativeBindings.nativeVr) {
           force: true,
         });
 
+        return canvas.framebuffer;
+      } else if (canvas.ownerDocument.framebuffer) {
+        const {width, height} = canvas;
+        const {msFbo, msTex, msDepthTex, fbo, tex, depthTex} = canvas.ownerDocument.framebuffer;
         return {
           width,
           height,
@@ -595,19 +599,24 @@ if (nativeBindings.nativeMl) {
 
           mlPresentState.mlGlContext = context;
 
-          return {
-            width,
-            height,
-            msFbo,
-            msTex,
-            msDepthTex,
-            fbo,
-            tex,
-            depthTex,
-          };
+          return canvas.framebuffer;
         } else {
           throw new Error('failed to present ml context');
         }
+      } else if (canvas.ownerDocument.framebuffer) {
+        const {width, height} = canvas;
+        const {msFbo, msTex, msDepthTex, fbo, tex, depthTex} = canvas.ownerDocument.framebuffer;
+        
+        return {
+          width,
+          height,
+          msFbo,
+          msTex,
+          msDepthTex,
+          fbo,
+          tex,
+          depthTex,
+        };
       } else {
         return {
           width: renderWidth * 2,

--- a/src/index.js
+++ b/src/index.js
@@ -193,8 +193,10 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
       // TODO: handle multiple child canvases
       document.framebuffer = {
         canvas,
+        msFbo,
         msTex,
         msDepthTex,
+        fbo,
         tex,
         depthTex,
       };

--- a/src/index.js
+++ b/src/index.js
@@ -365,10 +365,11 @@ const depthNear = 0.1;
 const depthFar = 10000.0;
 if (nativeBindings.nativeVr) {
   nativeBindings.nativeVr.requestPresent = function(layers) {
-    if (!vrPresentState.glContext) {
-      const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
-      if (layer) {
-        const canvas = layer.source;
+    const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
+    if (layer) {
+      const canvas = layer.source;
+      
+      if (!vrPresentState.glContext) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');
@@ -452,23 +453,23 @@ if (nativeBindings.nativeVr) {
           depthTex,
         };
       } else {
-        throw new Error('no HTMLCanvasElement source provided');
+        /* const {width: halfWidth, height} = vrPresentState.system.GetRecommendedRenderTargetSize();
+        const width = halfWidth * 2; */
+
+        const {msFbo, msTex, msDepthTex, fbo, tex, depthTex} = vrPresentState;
+        return {
+          width: renderWidth * 2,
+          height: renderHeight,
+          msFbo,
+          msTex,
+          msDepthTex,
+          fbo,
+          tex,
+          depthTex,
+        };
       }
     } else {
-      /* const {width: halfWidth, height} = vrPresentState.system.GetRecommendedRenderTargetSize();
-      const width = halfWidth * 2; */
-
-      const {msFbo, msTex, msDepthTex, fbo, tex, depthTex} = vrPresentState;
-      return {
-        width: renderWidth * 2,
-        height: renderHeight,
-        msFbo,
-        msTex,
-        msDepthTex,
-        fbo,
-        tex,
-        depthTex,
-      };
+      throw new Error('no HTMLCanvasElement source provided');
     }
   };
   nativeBindings.nativeVr.exitPresent = function() {
@@ -519,10 +520,11 @@ GlobalContext.mlPresentState = mlPresentState;
 if (nativeBindings.nativeMl) {
   mlPresentState.mlContext = new nativeBindings.nativeMl();
   nativeBindings.nativeMl.requestPresent = function(layers) {
-    if (!mlPresentState.mlGlContext) {
-      const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
-      if (layer) {
-        const canvas = layer.source;
+    const layer = layers.find(layer => layer && layer.source && layer.source.tagName === 'CANVAS');
+    if (layer) {
+      const canvas = layer.source;
+      
+      if (!mlPresentState.mlGlContext) {
         let context = canvas._context;
         if (!(context && context.constructor && context.constructor.name === 'WebGLRenderingContext')) {
           context = canvas.getContext('webgl');
@@ -607,19 +609,19 @@ if (nativeBindings.nativeMl) {
           throw new Error('failed to present ml context');
         }
       } else {
-        throw new Error('no HTMLCanvasElement source provided');
+        return {
+          width: renderWidth * 2,
+          height: renderHeight,
+          msFbo: mlPresentState.mlMsFbo,
+          msTex: mlPresentState.mlMsTex,
+          msDepthTex: mlPresentState.mlMsDepthTex,
+          fbo: mlPresentState.mlFbo,
+          tex: mlPresentState.mlTex,
+          depthTex: mlPresentState.mlDepthTex,
+        };
       }
     } else {
-      return {
-        width: renderWidth * 2,
-        height: renderHeight,
-        msFbo: mlPresentState.mlMsFbo,
-        msTex: mlPresentState.mlMsTex,
-        msDepthTex: mlPresentState.mlMsDepthTex,
-        fbo: mlPresentState.mlFbo,
-        tex: mlPresentState.mlTex,
-        depthTex: mlPresentState.mlDepthTex,
-      };
+      throw new Error('no HTMLCanvasElement source provided');
     }
   };
   nativeBindings.nativeMl.exitPresent = function() {


### PR DESCRIPTION
WebXR uses `session.baseLayer` to determine the framebuffer to blit from. This is an `XRWebGLLayer` constructed and set by three.js/your framework of choice. The framebuffer is selected at `XRWebGLLayer` construction time, based on the device that's currently presenting.

The problem is that since the session is shared across reality tabs, the presenting parent framebuffer was also selected as child framebuffer, causing the shared framebuffer to bleed across contexts.

This would especially manifest if a child reality tab would set the render target and then try to switch back to the `session.baseLayer` render target, which would then be the wrong one (the parent's).

The fix here is to pull the framebuffer from the gl layer's document framebuffer, rather than the one from the context.