### PR TITLE
Reality tabs: un-offset controller space of child tabs

### DIFF
--- a/examples/fakeDisplay.js
+++ b/examples/fakeDisplay.js
@@ -64,7 +64,6 @@ window._makeFakeDisplay = () => {
   const onends = [];
   fakeDisplay.requestSession = function({
     exclusive = true,
-    // xrOffset = null,
     stereo = false,
   } = {}) {
     const self = this;


### PR DESCRIPTION
#### Background

With reality tabs we have support for opening, rendering, and merging child iframe WebXR space into a parent WebXR space by setting the session layers array with regular iframes.

These child iframes can be offset from the parent by an arbitrary view transform, allowing sites to be placed into different relative spaces, just like a 2D iframe.

#### Problem

The problem is that the controller and other I/O space is offset due to the camera view space being offset. That is, the child tab thinks the controller is based on its own origin, which is offset from the parent origin, and therefore the child will render the controller in the wrong place, and take input from the wrong place.

#### Fix

This PR fixes the problem by translating the controller coordinates to the parent space on `getInputPose`.

Related to https://github.com/webmixedreality/exokit/pull/649/files, which fixed this for the emulated fake WebXR display in `fakeDisplay.js`.