### PR TITLE
Make Servo2D pbuffer match the display

### DIFF
--- a/deps/exokit-bindings/browser/src/Servo2D.cpp
+++ b/deps/exokit-bindings/browser/src/Servo2D.cpp
@@ -68,19 +68,14 @@ int Servo2D::init(
   this->display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
   EGLConfig eglConfig;
   EGLint eglConfigAttribs[] = {
-    /* EGL_RED_SIZE,   8,
-    EGL_GREEN_SIZE, 8,
-    EGL_BLUE_SIZE,  8,
-    EGL_ALPHA_SIZE, 8,     // if you need the alpha channel
-    EGL_DEPTH_SIZE, 16,    // if you need the depth buffer */
-    EGL_RED_SIZE, 8,
+    EGL_RED_SIZE, 5,
+    EGL_GREEN_SIZE, 6,
+    EGL_BLUE_SIZE,  5,
+    EGL_ALPHA_SIZE, 0,
+    /* EGL_RED_SIZE, 8,
     EGL_GREEN_SIZE, 8,
     EGL_BLUE_SIZE, 8,
-    EGL_ALPHA_SIZE, 8,
-    /* EGL_RED_SIZE,   8,
-    EGL_GREEN_SIZE, 8,
-    EGL_BLUE_SIZE,  8,
-    // EGL_ALPHA_SIZE, 0, */
+    EGL_ALPHA_SIZE, 8, */
     EGL_DEPTH_SIZE, 24,
     EGL_STENCIL_SIZE, 8,
     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,


### PR DESCRIPTION
This allows the Servo2D integration to work without needing the RGBA8 contexting in https://github.com/webmixedreality/exokit/pull/646.