### PR TITLE
Bump native-browser-deps-linux version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "native-browser-deps": "0.0.16",
     "native-browser-deps-windows": "0.0.1",
     "native-browser-deps-macos": "0.0.1",
-    "native-browser-deps-linux": "0.0.3",
+    "native-browser-deps-linux": "0.0.4",
     "native-browser-deps-magicleap": "0.0.1",
     "native-canvas-deps": "0.0.50",
     "native-graphics-deps": "0.0.20",


### PR DESCRIPTION
Bumps `native-browser-deps-linux` version to eliminate the long concat + extraction phase on non-linux platforms.

The effect of this should be faster builds outside of linux.