### PR TITLE
Devtools API async

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -1479,10 +1479,14 @@ function animate(time, frame) {
                           const tab = tabs[menuMesh.listMesh.scrollIndex + j];
                           const {iframe} = tab;
                           if (iframe.d === 3) {
-                            const {contentWindow} = iframe;
-                            const devTools = window.browser.devTools.createDevTools(contentWindow);
-                            const url = devTools.getUrl();
-                            _openUrl(url, rig.position, rig.quaternion, undefined, 2);
+                            window.browser.devTools.requestDevTools(iframe.contentWindow)
+                              .then(devTools => {
+                                const url = devTools.getUrl();
+                                _openUrl(url, rig.position, rig.quaternion, undefined, 2);
+                              })
+                              .catch(err => {
+                                console.warn(err.stack);
+                              });
                           }
                         }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fault-zone": "0.0.20",
     "he": "^1.1.1",
     "history": "^4.7.2",
-    "hterm-repl": "0.0.7",
+    "hterm-repl": "0.0.8",
     "isolator": "0.0.9",
     "leapmotion": "0.0.4",
     "libnode.a": "0.0.1",

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -8,13 +8,21 @@ const DEVTOOLS_PORT = 9223;
 
 const _getReplServer = (() => {
   let replServer = null;
-  return () => {
+  return new Promise((accept, reject) => {
     if (!replServer) {
-      replServer = htermRepl({
+      htermRepl({
         port: DEVTOOLS_PORT,
+      }, (err, newReplServer) => {
+        if (!err) {
+          replServer = newReplServer;
+          accept(replServer);
+        } else  {
+          reject(err);
+        }
       });
+    } else {
+      accept(replServer);
     }
-    return replServer;
   };
 })();
 

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -6,26 +6,28 @@ const {HTMLIframeElement} = DOM;
 
 const DEVTOOLS_PORT = 9223;
 
-let replServer = null;
-const _getReplServer = () => {
-  if (!replServer) {
-    replServer = htermRepl({
-      port: DEVTOOLS_PORT,
-    });
-  }
-  return replServer;
-};
+const _getReplServer = (() => {
+  let replServer = null;
+  return () => {
+    if (!replServer) {
+      replServer = htermRepl({
+        port: DEVTOOLS_PORT,
+      });
+    }
+    return replServer;
+  };
+})();
 
 let id = 0;
 class DevTools {
-  constructor(context) {
+  constructor(context, replServer) {
     this.context = context;
+    this.replServer = replServer;
     this.id = (++id) + '';
     this.repls = [];
 
-    const replServer = _getReplServer();
     this.onRepl = this.onRepl.bind(this);
-    replServer.on('repl', this.onRepl);
+    this.replServer.on('repl', this.onRepl);
   }
 
   getPath() {
@@ -54,8 +56,7 @@ class DevTools {
   }
 
   destroy() {
-    const replServer = _getReplServer();
-    replServer.removeListener('repl', this.onRepl);
+    this.replServer.removeListener('repl', this.onRepl);
 
     for (let i = 0; i < this.repls.length; i++) {
       this.repls[i].close();
@@ -65,7 +66,8 @@ class DevTools {
 }
 
 module.exports = {
-  createDevTools(iframe) {
-    return new DevTools(iframe);
+  async requestDevTools(iframe) {
+    const replServer = await _getReplServer();
+    return new DevTools(iframe, replServer);
   },
 };

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -8,7 +8,7 @@ const DEVTOOLS_PORT = 9223;
 
 const _getReplServer = (() => {
   let replServer = null;
-  return new Promise((accept, reject) => {
+  return () => new Promise((accept, reject) => {
     if (!replServer) {
       htermRepl({
         port: DEVTOOLS_PORT,

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -23,7 +23,7 @@ const _getReplServer = (() => {
     } else {
       accept(replServer);
     }
-  };
+  });
 })();
 
 let id = 0;


### PR DESCRIPTION
The way the devtools API works, we start a server that serves the devtools page for consumption by the embedded 2D browser (CEF/servo).

The problem is that if this is synchronous, we might not be listening before the browser tries to load the page, which will fail.

This PR converts the devtools API to be asytnchronous using promises, to eliminate the race condition.