### PR TITLE
Fix crash in image-context

### DIFF
--- a/deps/exokit-bindings/canvascontext/include/image-context.h
+++ b/deps/exokit-bindings/canvascontext/include/image-context.h
@@ -47,7 +47,7 @@ private:
   Nan::Persistent<ArrayBuffer> arrayBuffer;
   Nan::Persistent<Function> cbFn;
   std::string error;
-  uv_async_t threadAsync;
+  uv_async_t *threadAsyncHandle;
 
   friend class CanvasRenderingContext2D;
   friend class ImageData;


### PR DESCRIPTION
I have observed frequent crashes of Exokit when the web app is dealing with ajax-loaded images.  The following example reproduces the crash fairly reliably (not always though; maybe try several times in case the crash does not manifest in one shot).

```
$ node . -h https://j-devel.github.io/pixels-to-mesh-test/index.html
```

**Cause of the problem**

In `image-context.cc`, the `handle` in `uv_close()` points to `threadAsync` of `Image`.  But this address `&threadAsync` is no longer valid after the `Image` instance is destroyed.  Depending on the situations, `Image` destruction occurs _before_ the actual `uv_close()` operation is fulfilled, leading to unpredictable behaviors (mostly crashes with an assertion failure of `uv__finish_close`), e.g.

```
Assertion failed: (handle->flags & UV_HANDLE_CLOSING), function uv__finish_close, file ../deps/uv/src/unix/core.c, line 252.
Abort trap: 6
```

**Fix**

This PR is to allocate the async handle in heap and let `uv_close()` work properly without causing the crash.
