### PR TITLE
XR Devtools over console stream

### DIFF
--- a/deps/exokit-bindings/browser/include/browser-common.h
+++ b/deps/exokit-bindings/browser/include/browser-common.h
@@ -93,6 +93,7 @@ void embeddedRunJs(EmbeddedBrowser browser_, const std::string &jsString, const 
 // helpers
 
 void QueueOnBrowserThread(std::function<void()> fn);
+void QueueOnBrowserThreadFront(std::function<void()> fn);
 
 void RunOnMainThread(std::function<void()> fn);
 void QueueOnMainThread(std::function<void()> fn);

--- a/deps/exokit-bindings/browser/src/browser-common.cpp
+++ b/deps/exokit-bindings/browser/src/browser-common.cpp
@@ -17,7 +17,16 @@ namespace browser {
 void QueueOnBrowserThread(std::function<void()> fn) {
   {
     std::lock_guard<std::mutex> lock(browserThreadFnMutex);
-    browserThreadFns.push_front(fn); // push_front for fifo
+    browserThreadFns.push_back(fn);
+  }
+  
+  uv_sem_post(&browserThreadSem);
+}
+
+void QueueOnBrowserThreadFront(std::function<void()> fn) {
+  {
+    std::lock_guard<std::mutex> lock(browserThreadFnMutex);
+    browserThreadFns.push_front(fn);
   }
   
   uv_sem_post(&browserThreadSem);

--- a/deps/exokit-bindings/browser/src/browser.cpp
+++ b/deps/exokit-bindings/browser/src/browser.cpp
@@ -26,7 +26,7 @@ Browser::Browser(WebGLRenderingContext *gl, int width, int height, const std::st
   window = windowsystem::CreateNativeWindow(width, height, true, gl->windowHandle);
 #endif
   
-  QueueOnBrowserThread([&]() -> void {
+  QueueOnBrowserThreadFront([&]() -> void {
     this->loadImmediate(url, window, width, height);
 
     uv_sem_post(&constructSem);
@@ -136,7 +136,7 @@ NAN_METHOD(Browser::New) {
 }
 
 void Browser::load(const std::string &url) {
-  QueueOnBrowserThread([&]() -> void {
+  QueueOnBrowserThreadFront([&]() -> void {
     this->loadImmediate(url);
   
     uv_sem_post(&constructSem);

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -208,23 +208,6 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
     if (contentDocument) {
       _drawOk();
 
-      iframe.contentWindow.onmessage = m => {
-        console.log('parent got message: ' + JSON.stringify(m.data));
-      };
-
-      iframe.runJs(`
-        console.log('child run js');
-
-        // document.body.style.background = '#000080';
-        // console.log('run js log ' + typeof window.postMessage + ' ' + window.postMessage.toString());
-
-        /* window.onmessage = m => {
-          console.log('child got message: ' + JSON.stringify(m.data));
-        };
-
-        window.postMessage({lol: 'zol'}); */
-      `);
-
       // floorMesh.visible = false;
       // scene.background = null;
     } else {

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -222,10 +222,10 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
   };
   iframe.d = d;
   iframe.src = u;
-  iframe.addEventListener('destroy', () => {
+  /* iframe.addEventListener('destroy', () => {
     // floorMesh.visible = true;
     // scene.background = _makeBackground();
-  });
+  }); */
   document.body.appendChild(iframe);
 
   const tab = {

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -189,9 +189,9 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
   };
 
   const iframe = document.createElement('iframe');
-  iframe.position = position.toArray();
-  iframe.orientation = orientation.toArray();
-  iframe.scale = scale.toArray();
+  iframe.onconsole = (jsString, scriptUrl, startLine) => {
+    console.log('parent got console', {jsString, scriptUrl, startLine});
+  };
   iframe.onload = function() {
     const contentDocument = (() => {
       try {
@@ -207,6 +207,23 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
     })();
     if (contentDocument) {
       _drawOk();
+
+      iframe.contentWindow.onmessage = m => {
+        console.log('parent got message: ' + JSON.stringify(m.data));
+      };
+
+      iframe.runJs(`
+        console.log('child run js');
+
+        // document.body.style.background = '#000080';
+        // console.log('run js log ' + typeof window.postMessage + ' ' + window.postMessage.toString());
+
+        /* window.onmessage = m => {
+          console.log('child got message: ' + JSON.stringify(m.data));
+        };
+
+        window.postMessage({lol: 'zol'}); */
+      `);
 
       // floorMesh.visible = false;
       // scene.background = null;
@@ -226,20 +243,30 @@ const _openUrl = (u, position = new THREE.Vector3(), orientation = new THREE.Qua
     // floorMesh.visible = true;
     // scene.background = _makeBackground();
   }); */
+
+  _addTab(iframe, position, orientation, scale, d);
+  rig.menuMesh.urlMesh.updateText();
+  rig.menuMesh.listMesh.updateList();
+};
+const _addTab = (iframe, position = new THREE.Vector3(), orientation = new THREE.Quaternion(), scale, d = 3) => {
+  if (scale === undefined) {
+    scale = new THREE.Vector3(1, d === 3 ? 1 : window.innerHeight/window.innerWidth, 1)
+  }
+
+  iframe.position = position.toArray();
+  iframe.orientation = orientation.toArray();
+  iframe.scale = scale.toArray();
+
   document.body.appendChild(iframe);
 
   const tab = {
-    url: u,
+    url: iframe.src,
     iframe,
   };
   tabs.push(tab);
   layers.push(iframe);
 
   focusedTab = tab;
-  rig.menuMesh.urlMesh.updateText();
-  rig.menuMesh.listMesh.updateList();
-
-  return iframe;
 };
 const _closeUrl = iframe => {
   if (iframe.destroy) {
@@ -1479,10 +1506,9 @@ function animate(time, frame) {
                           const tab = tabs[menuMesh.listMesh.scrollIndex + j];
                           const {iframe} = tab;
                           if (iframe.d === 3) {
-                            window.browser.devTools.requestDevTools(iframe.contentWindow)
+                            window.browser.devTools.requestDevTools(iframe.contentWindow, document)
                               .then(devTools => {
-                                const url = devTools.getUrl();
-                                _openUrl(url, rig.position, rig.quaternion, undefined, 2);
+                                _addTab(devTools.getIframe(), rig.position, rig.quaternion, undefined, 2);
                               })
                               .catch(err => {
                                 console.warn(err.stack);

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fault-zone": "0.0.20",
     "he": "^1.1.1",
     "history": "^4.7.2",
-    "hterm-repl": "0.0.8",
+    "hterm-repl": "0.0.9",
     "isolator": "0.0.9",
     "leapmotion": "0.0.4",
     "libnode.a": "0.0.1",

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -28,8 +28,9 @@ const _getReplServer = (() => {
 
 let id = 0;
 class DevTools {
-  constructor(context, replServer) {
+  constructor(context, document, replServer) {
     this.context = context;
+    this.document = document;
     this.replServer = replServer;
     this.id = (++id) + '';
     this.repls = [];
@@ -74,8 +75,8 @@ class DevTools {
 }
 
 module.exports = {
-  async requestDevTools(iframe) {
+  async requestDevTools(context, document) {
     const replServer = await _getReplServer();
-    return new DevTools(iframe, replServer);
+    return new DevTools(context, document, replServer);
   },
 };

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -60,12 +60,8 @@ class DevTools {
     this.replServer.on('repl', this.onRepl);
   }
 
-  /* getPath() {
-    return `/?id=${this.id}`;
-  } */
   getUrl() {
      return `${this.replServer.url}&id=${this.id}`;
-    // return `http://127.0.0.1:${DEVTOOLS_PORT}${this.getPath()}`;
   }
 
   onRepl(r) {

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -1,3 +1,4 @@
+const url = require('url');
 const http = require('http');
 const htermRepl = require('hterm-repl');
 

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -64,6 +64,10 @@ class DevTools {
       });
     }
   }
+  
+  getIframe() {
+    return this.iframe;
+  }
 
   destroy() {
     this.replServer.removeListener('repl', this.onRepl);

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -39,11 +39,12 @@ class DevTools {
     this.replServer.on('repl', this.onRepl);
   }
 
-  getPath() {
+  /* getPath() {
     return `/?id=${this.id}`;
-  }
+  } */
   getUrl() {
-    return `http://127.0.0.1:${DEVTOOLS_PORT}${this.getPath()}`;
+     return `${this.replServer.url}&id=${this.id}`;
+    // return `http://127.0.0.1:${DEVTOOLS_PORT}${this.getPath()}`;
   }
 
   onRepl(r) {

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -5,15 +5,13 @@ const htermRepl = require('hterm-repl');
 const DOM = require('./DOM');
 const {HTMLIframeElement} = DOM;
 
-const DEVTOOLS_PORT = 9223;
+// const DEVTOOLS_PORT = 9223;
 
 const _getReplServer = (() => {
   let replServer = null;
   return () => new Promise((accept, reject) => {
     if (!replServer) {
-      htermRepl({
-        port: DEVTOOLS_PORT,
-      }, (err, newReplServer) => {
+      htermRepl(null, (err, newReplServer) => {
         if (!err) {
           replServer = newReplServer;
           accept(replServer);

--- a/src/DevTools.js
+++ b/src/DevTools.js
@@ -48,7 +48,7 @@ class DevTools {
   }
 
   onRepl(r) {
-    if (r.url === this.getPath()) {
+    if (r.id === this.id) {
       r.setEval((s, context, filename, cb) => {
         let err = null, result;
         try {


### PR DESCRIPTION
The in-world XR devtools for inspecting reality tabs `<iframes>` has thus far been using a local server + websocket for communication.

The problem with this is it's generally unsafe, takes a port, and some firewall settings (such as on Android devices) make it impossible to open a `localhost`-hosted page in an embedded 2D browser.

This PR update the XR devtools/hterm to use WebSocket emulation over `console`/`postMessage` instead, which turns out to not only be safer but faster as well, since there is no network overhead.