### PR TITLE
Bump window-selector version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "webgl-to-opengl": "0.0.12",
     "window-classlist": "0.0.4",
     "window-fetch": "0.0.9",
-    "window-selector": "0.0.5",
+    "window-selector": "0.0.6",
     "window-text-encoding": "0.0.2",
     "window-worker": "0.0.98",
     "window-xhr": "0.0.20",


### PR DESCRIPTION
This brings `div[attribute i]` selector capture support to Exokit's CSS selector engine.