### PR TITLE
Reality tabs default on Magic Leap

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char **argv) {
       if (access("/package/app/index.html", F_OK) != -1) {
         jsString = "/package/app/index.html";
       } else {
-        jsString = "examples/hello_ml.html";
+        jsString = "examples/realitytabs.html";
       }
       
       const char *nodeString = "node";

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.4",
     "native-browser-deps-macos": "0.0.1",
-    "native-browser-deps-magicleap": "0.0.4",
+    "native-browser-deps-magicleap": "0.0.5",
     "native-browser-deps-windows": "0.0.1",
     "native-canvas-deps": "0.0.50",
     "native-graphics-deps": "0.0.20",


### PR DESCRIPTION
This sets the reality tab example (which is capable of loading all of the other examples, simultaneously) as the default page to open in the Magic Leap case.

Additionally, bumps `native-browser-deps-magicleap` to fix key event bindings in `iframe` 2D, which was the last blocking issue for this.