### PR TITLE
AR floor origin

### DIFF
--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -293,7 +293,7 @@ public:
   static NAN_METHOD(Update);
   static NAN_METHOD(Poll);
 
-  static void TickFloor();
+  void TickFloor();
   static MLVec3f &&OffsetFloor(const MLVec3f &position);
 
 // protected:

--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -293,6 +293,9 @@ public:
   static NAN_METHOD(Update);
   static NAN_METHOD(Poll);
 
+  static void TickFloor();
+  static MLVec3f &&OffsetFloor(const MLVec3f &position);
+
 // protected:
   // EGL
   NATIVEwindow *window;

--- a/deps/exokit-bindings/magicleap/include/magicleap.h
+++ b/deps/exokit-bindings/magicleap/include/magicleap.h
@@ -294,7 +294,7 @@ public:
   static NAN_METHOD(Poll);
 
   void TickFloor();
-  static MLVec3f &&OffsetFloor(const MLVec3f &position);
+  static MLVec3f OffsetFloor(const MLVec3f &position);
 
 // protected:
   // EGL

--- a/deps/exokit-bindings/magicleap/include/ml-math.h
+++ b/deps/exokit-bindings/magicleap/include/ml-math.h
@@ -17,6 +17,7 @@ MLVec3f crossVectors(const MLVec3f &a, const MLVec3f &b);
 float vectorLengthSq(const MLVec3f &v);
 float vectorLength(const MLVec3f &v);
 MLVec3f normalizeVector(const MLVec3f &v);
+MLVec3f applyVectorQuaternion(const MLVec3f &v, const MLQuaternionf &q);
 MLVec3f applyVectorMatrix(const MLVec3f &v, const MLMat4f &m);
 float quaternionLength(const MLQuaternionf &q);
 MLQuaternionf normalizeQuaternion(const MLQuaternionf &q);

--- a/deps/exokit-bindings/magicleap/include/ml-math.h
+++ b/deps/exokit-bindings/magicleap/include/ml-math.h
@@ -39,6 +39,7 @@ void decomposeMatrix(
   MLQuaternionf &quaternion,
   MLVec3f &scale
 );
+MLMat4f makeTranslationMatrix(const MLVec3f &translation);
 MLMat4f invertMatrix(const MLMat4f &matrix);
 MLMat4f multiplyMatrices(const MLMat4f &a, const MLMat4f &b);
 bool isIdentityMatrix(const MLMat4f &m);

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -15,6 +15,8 @@ namespace ml {
 
 const char application_name[] = "com.exokit.app";
 constexpr int CAMERA_SIZE[] = {960, 540};
+constexpr float meshingRange = 3.0f;
+constexpr float planeRange = 10.0f;
 
 application_context_t application_context;
 MLResult lifecycle_status = MLResult_Pending;
@@ -3344,9 +3346,9 @@ NAN_METHOD(MLContext::Update) {
       // meshExtents.rotation =  mlContext->rotation;
       meshExtents.rotation = {0, 0, 0, 1};
     }
-    meshExtents.extents.x = 3;
-    meshExtents.extents.y = 3;
-    meshExtents.extents.z = 3;
+    meshExtents.extents.x = meshingRange;
+    meshExtents.extents.y = meshingRange;
+    meshExtents.extents.z = meshingRange;
 
     MLResult result = MLMeshingRequestMeshInfo(meshTracker, &meshExtents, &meshInfoRequestHandle);
     if (result == MLResult_Ok) {
@@ -3364,9 +3366,9 @@ NAN_METHOD(MLContext::Update) {
       // planesRequest.bounds_rotation = mlContext->rotation;
       planesRequest.bounds_rotation = {0, 0, 0, 1};
     }
-    planesRequest.bounds_extents.x = 3;
-    planesRequest.bounds_extents.y = 3;
-    planesRequest.bounds_extents.z = 3;
+    planesRequest.bounds_extents.x = planeRange;
+    planesRequest.bounds_extents.y = planeRange;
+    planesRequest.bounds_extents.z = planeRange;
 
     planesRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_All | MLPlanesQueryFlag_OrientToGravity;
     // planesRequest.min_hole_length = 0.5;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2788,9 +2788,10 @@ NAN_METHOD(MLContext::WaitGetPoses) {
         for (int i = 0; i < 2; i++) {
           const MLGraphicsVirtualCameraInfo &cameraInfo = mlContext->virtual_camera_array.virtual_cameras[i];
           const MLTransform &transform = cameraInfo.transform;
-          transformArray->Set(i*7 + 0, JS_NUM(transform.position.x));
-          transformArray->Set(i*7 + 1, JS_NUM(transform.position.y));
-          transformArray->Set(i*7 + 2, JS_NUM(transform.position.z));
+          const MLVec3f &position = OffsetFloor(transform.position);
+          transformArray->Set(i*7 + 0, JS_NUM(position.x));
+          transformArray->Set(i*7 + 1, JS_NUM(position.y));
+          transformArray->Set(i*7 + 2, JS_NUM(position.z));
           transformArray->Set(i*7 + 3, JS_NUM(transform.rotation.x));
           transformArray->Set(i*7 + 4, JS_NUM(transform.rotation.y));
           transformArray->Set(i*7 + 5, JS_NUM(transform.rotation.z));
@@ -2807,7 +2808,7 @@ NAN_METHOD(MLContext::WaitGetPoses) {
           // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
           const MLTransform &leftCameraTransform = mlContext->virtual_camera_array.virtual_cameras[0].transform;
-          mlContext->position = leftCameraTransform.position;
+          mlContext->position = OffsetFloor(leftCameraTransform.position);
           mlContext->rotation = leftCameraTransform.rotation;
         }
 
@@ -2817,7 +2818,7 @@ NAN_METHOD(MLContext::WaitGetPoses) {
         if (result == MLResult_Ok) {
           for (int i = 0; i < 2 && i < MLInput_MaxControllers; i++) {
             const MLInputControllerState &controllerState = controllerStates[i];
-            const MLVec3f &position = controllerState.position;
+            const MLVec3f &position = OffsetFloor(controllerState.position);
             const MLQuaternionf &orientation = controllerState.orientation;
             const float trigger = controllerState.trigger_normalized;
             const float bumper = controllerState.button_state[MLInputControllerButton_Bumper] ? 1.0f : 0.0f;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2782,6 +2782,8 @@ NAN_METHOD(MLContext::WaitGetPoses) {
       result = MLGraphicsBeginFrame(mlContext->graphics_client, &frame_params, &mlContext->frame_handle, &mlContext->virtual_camera_array);
 
       if (result == MLResult_Ok) {
+        TickFloor();
+
         // transform
         for (int i = 0; i < 2; i++) {
           const MLGraphicsVirtualCameraInfo &cameraInfo = mlContext->virtual_camera_array.virtual_cameras[i];

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -3343,7 +3343,7 @@ NAN_METHOD(MLContext::Update) {
     planesRequest.bounds_extents.y = 3;
     planesRequest.bounds_extents.z = 3;
 
-    planesRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_All;
+    planesRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_All | MLPlanesQueryFlag_OrientToGravity;
     planesRequest.min_hole_length = 0.5;
     planesRequest.min_plane_area = 0.25;
     planesRequest.max_results = MAX_NUM_PLANES;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -3570,7 +3570,7 @@ void MLContext::TickFloor() {
     floorRequest.bounds_extents.y = planeRange;
     floorRequest.bounds_extents.z = planeRange;
 
-    floorRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_Floor | MLPlanesQueryFlag_OrientToGravity;
+    floorRequest.flags = MLPlanesQueryFlag_Horizontal | MLPlanesQueryFlag_Semantic_Floor;
     // floorRequest.min_hole_length = 0.5;
     floorRequest.min_plane_area = 0.25;
     floorRequest.max_results = MAX_NUM_PLANES;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -2670,7 +2670,7 @@ NAN_METHOD(MLContext::Present) {
     return;
   }
 
-  TickFloor();
+  mlContext->TickFloor();
 
   // HACK: force the app to be "running"
   application_context.dummy_value = DummyValue::RUNNING;
@@ -2788,7 +2788,7 @@ NAN_METHOD(MLContext::WaitGetPoses) {
       result = MLGraphicsBeginFrame(mlContext->graphics_client, &frame_params, &mlContext->frame_handle, &mlContext->virtual_camera_array);
 
       if (result == MLResult_Ok) {
-        TickFloor();
+        mlContext->TickFloor();
 
         // transform
         for (int i = 0; i < 2; i++) {
@@ -3562,7 +3562,7 @@ void MLContext::TickFloor() {
     {
       // std::unique_lock<std::mutex> lock(mlContext->positionMutex);
 
-      floorRequest.bounds_center = mlContext->position;
+      floorRequest.bounds_center = this->position;
       // floorRequest.bounds_rotation = mlContext->rotation;
       floorRequest.bounds_rotation = {0, 0, 0, 1};
     }

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -80,8 +80,8 @@ MLHandle floorRequestHandle;
 MLPlane floorResults[MAX_NUM_PLANES];
 uint32_t numFloorResults;
 bool floorRequestPending = false;
-float largestPlaneY = 0;
-float largestPlaneSizeSq = 0;
+float largestFloorY = 0;
+float largestFloorSizeSq = 0;
 
 MLHandle meshTracker;
 std::vector<MLMesher *> meshers;
@@ -318,8 +318,8 @@ MLMat4f getWindowTransformMatrix(Local<Object> windowObj) {
     };
   }
 
-  if (largestPlaneY != 0) {
-    result = multiplyMatrices(makeTranslationMatrix(MLVec3f{0, largestPlaneY, 0}), result);
+  if (largestFloorY != 0) {
+    result = multiplyMatrices(makeTranslationMatrix(MLVec3f{0, largestFloorY, 0}), result);
   }
 
   return result;
@@ -3588,11 +3588,11 @@ void MLContext::TickFloor() {
     if (result == MLResult_Ok) {
       for (uint32_t i = 0; i < numFloorResults; i++) {
         const MLPlane &plane = floorResults[i];
-        const float planeSizeSq = plane.width*plane.width + plane.height*plane.height;
+        const float floorSizeSq = plane.width*plane.width + plane.height*plane.height;
 
-        if (planeSizeSq > largestPlaneSizeSq) {
-          largestPlaneY = plane.position.y;
-          largestPlaneSizeSq = planeSizeSq;
+        if (floorSizeSq > largestFloorSizeSq) {
+          largestFloorY = plane.position.y;
+          largestFloorSizeSq = floorSizeSq;
         }
       }
 
@@ -3608,7 +3608,7 @@ void MLContext::TickFloor() {
 }
 
 MLVec3f &&MLContext::OffsetFloor(const MLVec3f &position) {
-  return MLVec3f{position.x, position.y + largestPlaneY, position.z};
+  return MLVec3f{position.x, position.y + largestFloorY, position.z};
 }
 
 }

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -3607,7 +3607,7 @@ void MLContext::TickFloor() {
   }
 }
 
-MLVec3f &&MLContext::OffsetFloor(const MLVec3f &position) {
+MLVec3f MLContext::OffsetFloor(const MLVec3f &position) {
   return MLVec3f{position.x, position.y + largestFloorY, position.z};
 }
 

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -319,7 +319,7 @@ MLMat4f getWindowTransformMatrix(Local<Object> windowObj) {
   }
 
   if (largestFloorY != 0) {
-    result = multiplyMatrices(makeTranslationMatrix(MLVec3f{0, largestFloorY, 0}), result);
+    result = multiplyMatrices(makeTranslationMatrix(MLVec3f{0, -largestFloorY, 0}), result);
   }
 
   return result;
@@ -3608,7 +3608,7 @@ void MLContext::TickFloor() {
 }
 
 MLVec3f MLContext::OffsetFloor(const MLVec3f &position) {
-  return MLVec3f{position.x, position.y + largestFloorY, position.z};
+  return MLVec3f{position.x, position.y - largestFloorY, position.z};
 }
 
 }

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -305,18 +305,24 @@ static void onUnloadResources(void* application_context) {
 MLMat4f getWindowTransformMatrix(Local<Object> windowObj) {
   Local<Object> localDocumentObj = Local<Object>::Cast(windowObj->Get(JS_STR("document")));
   Local<Value> xrOffsetValue = localDocumentObj->Get(JS_STR("xrOffset"));
+
+  MLMat4f result;
   if (xrOffsetValue->IsObject()) {
     Local<Object> xrOffsetObj = Local<Object>::Cast(xrOffsetValue);
     Local<Float32Array> matrixInverseFloat32Array = Local<Float32Array>::Cast(xrOffsetObj->Get(JS_STR("matrixInverse")));
     
-    MLMat4f transformMatrix;
-    memcpy(transformMatrix.matrix_colmajor, (char *)matrixInverseFloat32Array->Buffer()->GetContents().Data() + matrixInverseFloat32Array->ByteOffset(), sizeof(transformMatrix.matrix_colmajor));
-    return transformMatrix;
+    memcpy(result.matrix_colmajor, (char *)matrixInverseFloat32Array->Buffer()->GetContents().Data() + matrixInverseFloat32Array->ByteOffset(), sizeof(result.matrix_colmajor));
   } else {
-    return MLMat4f{
+    result = MLMat4f{
       {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1},
     };
   }
+
+  if (largestPlaneY != 0) {
+    result = multiplyMatrices(makeTranslationMatrix(MLVec3f{0, largestPlaneY, 0}), result);
+  }
+
+  return result;
 }
 
 // MLRaycaster

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -3344,7 +3344,7 @@ NAN_METHOD(MLContext::Update) {
     planesRequest.bounds_extents.z = 3;
 
     planesRequest.flags = MLPlanesQueryFlag_Arbitrary | MLPlanesQueryFlag_AllOrientations | MLPlanesQueryFlag_Semantic_All | MLPlanesQueryFlag_OrientToGravity;
-    planesRequest.min_hole_length = 0.5;
+    // planesRequest.min_hole_length = 0.5;
     planesRequest.min_plane_area = 0.25;
     planesRequest.max_results = MAX_NUM_PLANES;
 

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -3588,11 +3588,14 @@ void MLContext::TickFloor() {
     if (result == MLResult_Ok) {
       for (uint32_t i = 0; i < numFloorResults; i++) {
         const MLPlane &plane = floorResults[i];
-        const float floorSizeSq = plane.width*plane.width + plane.height*plane.height;
+        const MLVec3f &normal = applyVectorQuaternion(MLVec3f{0, 0, 1}, plane.rotation);
+        if (normal.y > 0) {
+          const float floorSizeSq = plane.width*plane.width + plane.height*plane.height;
 
-        if (floorSizeSq > largestFloorSizeSq) {
-          largestFloorY = plane.position.y;
-          largestFloorSizeSq = floorSizeSq;
+          if (floorSizeSq > largestFloorSizeSq) {
+            largestFloorY = plane.position.y;
+            largestFloorSizeSq = floorSizeSq;
+          }
         }
       }
 

--- a/deps/exokit-bindings/magicleap/src/ml-math.cc
+++ b/deps/exokit-bindings/magicleap/src/ml-math.cc
@@ -54,6 +54,27 @@ MLVec3f normalizeVector(const MLVec3f &v) {
   return divideVector(v, vectorLength(v));
 }
 
+
+MLVec3f applyVectorQuaternion(const MLVec3f &v, const MLQuaternionf &q) {
+  const float x = v.x, y = v.y, z = v.z;
+  const float qx = q.x, qy = q.y, qz = q.z, qw = q.w;
+
+  // calculate quat * vector
+
+  const float ix = qw * x + qy * z - qz * y;
+  const float iy = qw * y + qz * x - qx * z;
+  const float iz = qw * z + qx * y - qy * x;
+  const float iw = - qx * x - qy * y - qz * z;
+
+  // calculate result * inverse quat
+
+  return MLVec3f{
+    ix * qw + iw * - qx + iy * - qz - iz * - qy,
+    iy * qw + iw * - qy + iz * - qx - ix * - qz,
+    iz * qw + iw * - qz + ix * - qy - iy * - qx
+  };
+}
+
 MLVec3f applyVectorMatrix(const MLVec3f &v, const MLMat4f &m) {
   const float x = v.x, y = v.y, z = v.z;
   const float *e = m.matrix_colmajor;

--- a/deps/exokit-bindings/magicleap/src/ml-math.cc
+++ b/deps/exokit-bindings/magicleap/src/ml-math.cc
@@ -392,6 +392,17 @@ void decomposeMatrix(
   scale.z = sz;
 }
 
+MLMat4f makeTranslationMatrix(const MLVec3f &translation) {
+  return MLMat4f{
+    {
+      1, 0, 0, translation.x,
+      0, 1, 0, translation.y,
+      0, 0, 1, translation.z,
+      0, 0, 0, 1
+    }
+  };
+}
+
 MLMat4f invertMatrix(const MLMat4f &matrix) {
   MLMat4f result;
 

--- a/deps/exokit-bindings/magicleap/src/ml-math.cc
+++ b/deps/exokit-bindings/magicleap/src/ml-math.cc
@@ -416,10 +416,10 @@ void decomposeMatrix(
 MLMat4f makeTranslationMatrix(const MLVec3f &translation) {
   return MLMat4f{
     {
-      1, 0, 0, translation.x,
-      0, 1, 0, translation.y,
-      0, 0, 1, translation.z,
-      0, 0, 0, 1
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      translation.x, translation.y, translation.z, 1
     }
   };
 }

--- a/src/XR.js
+++ b/src/XR.js
@@ -387,8 +387,7 @@ class XRPresentationFrame {
       if (xrOffset) {
         localMatrix
           .premultiply(
-            localMatrix2.fromArray(xrOffset.matrix)
-            .getInverse(localMatrix2)
+            localMatrix2.fromArray(xrOffset.matrixInverse)
           );
       }
     }


### PR DESCRIPTION
Fixes #391.
Fixes #506.

WebXR specifies that the origin of the XR coordinate frame should be the floor. This is not currently true (on Magic Leap), resulting in the sky content problem, which many people just hack around by moving content down.

This is suboptimal not only because it requires content to change based on AR user agent, but it also means that content written for VR sometimes needs tweaks for AR, which it shouldn't.

This PR uses the AR render loop to detect the floor and orient the XR origin to be at the largest "floor" type plane we see.

Supersedes https://github.com/webmixedreality/exokit/pull/607.