### PR TITLE
<canvas> toDataURL/toBlob base64

### DIFF
--- a/deps/exokit-bindings/canvascontext/include/canvas-context.h
+++ b/deps/exokit-bindings/canvascontext/include/canvas-context.h
@@ -146,7 +146,7 @@ public:
   static NAN_METHOD(PutImageData);
   static NAN_METHOD(Save);
   static NAN_METHOD(Restore);
-  static NAN_METHOD(ToDataURL);
+  static NAN_METHOD(ToArrayBuffer);
   static NAN_METHOD(Destroy);
   static NAN_METHOD(GetWindowHandle);
   static NAN_METHOD(SetWindowHandle);

--- a/deps/exokit-bindings/canvascontext/src/canvas-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/canvas-context.cc
@@ -1256,7 +1256,7 @@ NAN_METHOD(CanvasRenderingContext2D::ToArrayBuffer) {
   sk_sp<SkImage> image = getImageFromContext(context);
   sk_sp<SkData> data = image->encodeToData(format, quality);
 
-  Local<ArrayBuffer> result = Nan::New<ArrayBuffer>(data->size());
+  Local<ArrayBuffer> result = ArrayBuffer::New(Isolate::GetCurrent(), data->size());
   memcpy(result->GetContents().Data(), data->data(), data->size());
   result->Set(JS_STR("type"), JS_STR(type));
   info.GetReturnValue().Set(result);

--- a/deps/exokit-bindings/canvascontext/src/canvas-context.cc
+++ b/deps/exokit-bindings/canvascontext/src/canvas-context.cc
@@ -90,7 +90,7 @@ Handle<Object> CanvasRenderingContext2D::Initialize(Isolate *isolate, Local<Valu
   Nan::SetMethod(proto, "drawImage", ctxCallWrap<DrawImage>);
   Nan::SetMethod(proto, "save", ctxCallWrap<Save>);
   Nan::SetMethod(proto, "restore", ctxCallWrap<Restore>);
-  Nan::SetMethod(proto, "toDataURL", ctxCallWrap<ToDataURL>);
+  Nan::SetMethod(proto, "toArrayBuffer", ctxCallWrap<ToArrayBuffer>);
   Nan::SetMethod(proto, "createImageData", ctxCallWrap<CreateImageData>);
   Nan::SetMethod(proto, "getImageData", ctxCallWrap<GetImageData>);
   Nan::SetMethod(proto, "putImageData", ctxCallWrap<PutImageData>);
@@ -1228,9 +1228,7 @@ NAN_METHOD(CanvasRenderingContext2D::Restore) {
   context->Restore();
 }
 
-#define DATA_URL_PREFIX "data:"
-#define DATA_URL_SUFFIX ";base64,"
-NAN_METHOD(CanvasRenderingContext2D::ToDataURL) {
+NAN_METHOD(CanvasRenderingContext2D::ToArrayBuffer) {
   // Nan::HandleScope scope;
 
   std::string type;
@@ -1258,18 +1256,9 @@ NAN_METHOD(CanvasRenderingContext2D::ToDataURL) {
   sk_sp<SkImage> image = getImageFromContext(context);
   sk_sp<SkData> data = image->encodeToData(format, quality);
 
-  std::vector<char> s(sizeof(DATA_URL_PREFIX)-1 + type.size() + sizeof(DATA_URL_SUFFIX)-1 + data->size());
-  int i = 0;
-  memcpy(s.data() + i, (void *)DATA_URL_PREFIX, sizeof(DATA_URL_PREFIX)-1);
-  i += sizeof(DATA_URL_PREFIX)-1;
-  memcpy(s.data() + i, type.data(), type.size());
-  i += type.size();
-  memcpy(s.data() + i, (void *)DATA_URL_SUFFIX, sizeof(DATA_URL_SUFFIX)-1);
-  i += sizeof(DATA_URL_SUFFIX)-1;
-  memcpy(s.data() + i, data->data(), data->size());
-  i += data->size();
-
-  Local<String> result = Nan::New<String>(s.data(), s.size()).ToLocalChecked();
+  Local<ArrayBuffer> result = Nan::New<ArrayBuffer>(data->size());
+  memcpy(result->GetContents().Data(), data->data(), data->size());
+  result->Set(JS_STR("type"), JS_STR(type));
   info.GetReturnValue().Set(result);
 }
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -8,6 +8,8 @@ const he = require('he');
 const parse5 = require('parse5');
 const parseIntStrict = require('parse-int');
 const selector = require('window-selector');
+const fetch = require('window-fetch');
+const {Blob} = fetch;
 
 const bindings = require('./bindings');
 const {defaultCanvasSize} = require('./constants');
@@ -2200,11 +2202,25 @@ class HTMLCanvasElement extends HTMLElement {
     return this._context;
   }
 
-  toDataURL() {
+  toDataURL(type, encoderOptions) {
+    const arrayBuffer = this.toArrayBuffer(type, encoderOptions);
+    return `data:${arrayBuffer.type};base64,${new Buffer(arrayBuffer).toString('base64')}`;
+  }
+
+  toBlob(cb, type, encoderOptions) {
+    process.nextTick(() => {
+      const arrayBuffer = this.toArrayBuffer(type, encoderOptions);
+      const blob = new Blob();
+      blob.buffer = new Buffer(arrayBuffer);
+      cb(blob);
+    });
+  }
+
+  toArrayBuffer(cb, type, encoderOptions) {
     if (!this._context) {
       this.getContext('2d');
     }
-    return this._context.toDataURL();
+    return this._context.toArrayBuffer(type, encoderOptions);
   }
 
   captureStream(frameRate) {


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/704.

Previously we were writing a binary string in the `toDataURL` codepath. This PR makes Skia return an `ArrayBuffer` instead, which we consume with `toDataURL` and convert to `base64` there.

Additionally, this adds `toBlob` support since with this architecture it was straightforward to implement.