### PR TITLE
Bugfix AR requestHitTest

### DIFF
--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -368,6 +368,8 @@ bool MLRaycaster::Update() {
           };
           asyncResource.MakeCallback(cb, sizeof(argv)/sizeof(argv[0]), argv);
         }
+        
+        delete this;
       }));
     } else {
       Local<Object> localWindowObj = Nan::New(this->windowObj);
@@ -384,15 +386,17 @@ bool MLRaycaster::Update() {
           };
           asyncResource.MakeCallback(cb, sizeof(argv)/sizeof(argv[0]), argv);
         }
+        
+        delete this;
       }));
     }
-
+    
     return true;
   } else if (result == MLResult_Pending) {
     return false;
   } else {
     ML_LOG(Error, "%s: Raycast request failed! %x", application_name, result);
-
+    delete this;
     return true;
   }
 }
@@ -3038,26 +3042,20 @@ NAN_METHOD(MLContext::RequestPlaneTracking) {
 
 NAN_METHOD(MLContext::RequestHitTest) {
   if (
-    info[0]->IsObject() && Local<Object>::Cast(info[0])->Get(JS_STR("constructor"))->ToObject()->Get(JS_STR("name"))->StrictEquals(JS_STR("XRRay")) &&
-    info[1]->IsFunction() &&
-    info[2]->IsObject()
+    info[0]->IsFloat32Array() &&
+    info[1]->IsFloat32Array() &&
+    info[2]->IsFunction() &&
+    info[3]->IsObject()
   ) {
-    Local<Object> xrRay = Local<Object>::Cast(info[0]);
-    Local<Object> origin = Local<Object>::Cast(xrRay->Get(JS_STR("origin")));
-    Local<Object> direction = Local<Object>::Cast(xrRay->Get(JS_STR("direction")));
-    Local<Function> cb = Local<Function>::Cast(info[1]);
-    Local<Object> windowObj = Local<Object>::Cast(info[2]);
+    Local<Float32Array> originFloat32Array = Local<Float32Array>::Cast(info[0]);
+    Local<Float32Array> directionFloat32Array = Local<Float32Array>::Cast(info[1]);
+    Local<Function> cb = Local<Function>::Cast(info[2]);
+    Local<Object> windowObj = Local<Object>::Cast(info[3]);
+    
+    // XXX transform from child to parent
 
-    raycastQuery.position = MLVec3f{
-      (float)origin->Get(JS_STR("x"))->NumberValue(),
-      (float)origin->Get(JS_STR("y"))->NumberValue(),
-      (float)origin->Get(JS_STR("z"))->NumberValue(),
-    };
-    raycastQuery.direction = MLVec3f{
-      (float)direction->Get(JS_STR("x"))->NumberValue(),
-      (float)direction->Get(JS_STR("y"))->NumberValue(),
-      (float)direction->Get(JS_STR("z"))->NumberValue(),
-    };
+    memcpy(raycastQuery.position.values, (char *)originFloat32Array->Buffer()->GetContents().Data() + originFloat32Array->ByteOffset(), sizeof(raycastQuery.position.values));
+    memcpy(raycastQuery.direction.values, (char *)directionFloat32Array->Buffer()->GetContents().Data() + directionFloat32Array->ByteOffset(), sizeof(raycastQuery.direction.values));
     raycastQuery.up_vector = MLVec3f{0, 1, 0};
     raycastQuery.horizontal_fov_degrees = 30;
     raycastQuery.width = 1;
@@ -3275,7 +3273,7 @@ NAN_METHOD(MLContext::Update) {
   if (raycasters.size() > 0) {
     raycasters.erase(std::remove_if(raycasters.begin(), raycasters.end(), [&](MLRaycaster *r) -> bool {
       if (r->Update()) {
-        delete r;
+        // deletion is handled by MLRaycaster
         return true;
       } else {
         return false;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -3059,6 +3059,7 @@ NAN_METHOD(MLContext::RequestHitTest) {
       (float)direction->Get(JS_STR("z"))->NumberValue(),
     };
     raycastQuery.up_vector = MLVec3f{0, 1, 0};
+    raycastQuery.horizontal_fov_degrees = 30;
     raycastQuery.width = 1;
     raycastQuery.height = 1;
     raycastQuery.collide_with_unobserved = false;

--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -3069,7 +3069,7 @@ NAN_METHOD(MLContext::RequestHitTest) {
       MLRaycaster *raycaster = new MLRaycaster(windowObj, requestHandle, cb);
       raycasters.push_back(raycaster);
     } else {
-      ML_LOG(Error, "%s: Failed to request raycast: %x", application_name, result);
+      ML_LOG(Error, "%s: Failed to request raycast: %x %x", application_name, result);
       Nan::ThrowError("failed to request raycast");
     }
   } else {

--- a/src/XR.js
+++ b/src/XR.js
@@ -155,10 +155,10 @@ class XRSession extends EventTarget {
       return result;
     }
   }
-  requestHitTest(ray, coordinateSystem) {
+  requestHitTest(origin, direction, coordinateSystem) {
     return new Promise((accept, reject) => {
       if (this.device.onrequesthittest)  {
-        this.device.onrequesthittest(ray, coordinateSystem, result => {
+        this.device.onrequesthittest(origin, direction, result => {
           accept(result);
         });
       } else {

--- a/src/core.js
+++ b/src/core.js
@@ -1717,7 +1717,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     _bindMRDisplay(mlDisplay);
     mlDisplay.onrequestpresent = layers => nativeMl.requestPresent(layers);
     mlDisplay.onexitpresent = () => nativeMl.exitPresent();
-    mlDisplay.onrequesthittest = (xrRay, cb) => nativeMl.requestHitTest(xrRay, cb, window);
+    mlDisplay.onrequesthittest = (origin, direction, cb) => nativeMl.RequestHitTest(origin, direction, cb, window);
     mlDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };
@@ -1737,7 +1737,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
           return session;
         });
     })(xmDisplay.requestSession);
-    xmDisplay.onrequesthittest = (xrRay, cb) => nativeMl.requestHitTest(xrRay, cb, window);
+    xmDisplay.onrequesthittest = (origin, direction, cb) => nativeMl.RequestHitTest(origin, direction, cb, window);
     xmDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };


### PR DESCRIPTION
The previous stub was using `XRRay` instead of origin/direction as used by the [WebXR samples](https://github.com/immersive-web/webxr-samples/blob/ddcb40e3b86f01d481461b4c856808988fab9610/proposals/phone-ar-hit-test.html#L217).

This adds a compatible WebXR `requestHitTest` API backed by magic leap's raycasting support.