### PR TITLE
Update BUILDING.md Magic Leap signed instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -45,7 +45,7 @@ Exokit is a node module. The core is written in Javascript, with native bindings
 1. place certificate/private key in `cert/{app.cert,app.privkey}`
 1. open **Ubuntu Bash on Windows**
 1. `export MLSDK=/mnt/c/your_mlsdk_path_goes_here # fill this in`
-1. run `scripts/build-ml.sh --signed`
+1. run `scripts/build-ml.sh`
 
 ### Procedure (unsigned)
 1. download Magic Leap Package Manager from https://creator.magicleap.com


### PR DESCRIPTION
The build-ml.sh `--signed` arg was previously removed ( https://github.com/webmixedreality/exokit/commit/b6c17b24387eae47ecd76a8c11204741700b1f4f#diff-9a4c9d3e3677de278c34f29937c44473L61 ). 

The build-ml script now signs by default ( https://github.com/webmixedreality/exokit/blob/master/scripts/build-ml.sh#L56 ).