### PR TITLE
Reality tabs depth population

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -2111,6 +2111,11 @@ if (navigator.xr && !query.fake) {
         renderer.vr.setDevice(display);
         renderer.vr.setAnimationLoop(animate);
 
+        if (window.browser && window.browser.magicleap) {
+          window.browser.magicleap.RequestDepthPopulation(true);
+          renderer.autoClearDepth = false;
+        }
+
         _openUrl('exobot.html');
         _updateRigLists();
 

--- a/src/core.js
+++ b/src/core.js
@@ -1360,7 +1360,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
       RequestHandTracking: () => nativeMl.RequestHandTracking(window),
       RequestEyeTracking: () => nativeMl.RequestEyeTracking(window),
       RequestImageTracking: () => nativeMl.RequestImageTracking(window),
-      RequestDepthPopulation: () => nativeMl.RequestDepthPopulation(window),
+      RequestDepthPopulation: nativeMl.RequestDepthPopulation,
       RequestCamera(cb) {
         if (typeof cb === 'function') {
           cb = (cb => function(datas) {


### PR DESCRIPTION
This set the reality tabs example HTML to request depth buffer population for magic leap. This gives mesh occlusion by default, which is the most natural boot environment for reality tabs.