### PR TITLE
Bugfix macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
   - os: osx
     osx_image: xcode10.1
     before_install:
+    - brew install ruby
     - brew install glfw glew
     install:
     - npm install -g appdmg

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,6 @@ matrix:
       skip_cleanup: true
   - os: osx
     osx_image: xcode10.1
-    before_install:
-    - brew install ruby
-    - brew install glfw glew
     install:
     - npm install -g appdmg
     - curl "https://nodejs.org/dist/v10.14.2/node-v10.14.2-darwin-x64.tar.gz" >node.tar.gz


### PR DESCRIPTION
For some reason Travis started erroring macos builds on homebrew install of `glfw` and `glew`. There was no change on our end, so it's probably a travis environment/homebrew update.

Apparently the brew install might not be needed at all, because removing it fixes the macOS build.