### PR TITLE
macOS: reality tabs composition shader

### DIFF
--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -63,7 +63,7 @@ out vec4 fragColor;\n\
 uniform sampler2D tex;\n\
 \n\
 void main() {\n\
-  fragColor = texture2D(tex, vUv);\n\
+  fragColor = texture(tex, vUv);\n\
 }\n\
 ";
 


### PR DESCRIPTION
MacOS doesn't like `texture2D` in higher OpenGL modes and fails the shader compilation. The replacement function for this is simply `texture`, which this PR swaps for.

Fixes some macOS render glitching, especially in reality tabs composition.