### PR TITLE
RequestHitTest XROffset reality tabs binding

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -791,6 +791,7 @@ const _makeRequestAnimationFrame = window => (fn, priority = 0) => {
   rafCbs.sort((a, b) => (b ? b[symbols.prioritySymbol] : 0) - (a ? a[symbols.prioritySymbol] : 0));
   return id;
 };
+const _makeOnRequestHitTest = window => (origin, direction, cb) => nativeMl.RequestHitTest(origin, direction, cb, window);
 const _getFakeVrDisplay = window => {
   const {fakeVrDisplay} = window[symbols.mrDisplaysSymbol];
   return fakeVrDisplay.isActive ? fakeVrDisplay : null;
@@ -802,6 +803,7 @@ const _cloneMrDisplays = (mrDisplays, window) => {
   for (const k in mrDisplays) {
     const mrDisplayClone = mrDisplays[k].clone();
     mrDisplayClone.onrequestanimationframe = _makeRequestAnimationFrame(window);
+    mrDisplayClone.onrequesthittest = _makeOnRequestHitTest(window);
     mrDisplayClone.window = window;
     result[k] = mrDisplayClone;
   }
@@ -1732,7 +1734,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     _bindMRDisplay(mlDisplay);
     mlDisplay.onrequestpresent = layers => nativeMl.requestPresent(layers);
     mlDisplay.onexitpresent = () => nativeMl.exitPresent();
-    mlDisplay.onrequesthittest = (origin, direction, cb) => nativeMl.RequestHitTest(origin, direction, cb, window);
+    mlDisplay.onrequesthittest = _makeOnRequestHitTest(window);
     mlDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };
@@ -1752,7 +1754,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
           return session;
         });
     })(xmDisplay.requestSession);
-    xmDisplay.onrequesthittest = (origin, direction, cb) => nativeMl.RequestHitTest(origin, direction, cb, window);
+    xmDisplay.onrequesthittest = _makeOnRequestHitTest(window);
     xmDisplay.onlayers = layers => {
       GlobalContext.mlPresentState.layers = layers;
     };


### PR DESCRIPTION
As usual for reality tabs with an `XROffset`, API requests to IRL apis like requestHitTest need to be offset accordingly to the matrices of the reality tabs iframe.

This _was_ being done for `requestHitTest` but it was being done for the wrong `window` in the reality tabs case due to a core.js closure.

This PR fixes that by binding to the correct `window` and therefore the correct `XROffset` for this API.