### PR TITLE
Reality tabs keyboard keys rendering

### DIFF
--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -1119,8 +1119,8 @@ const _animateRig = () => {
 };
 
 const cacheCanvas = document.createElement('canvas');
-cacheCanvas.width = 256;
-cacheCanvas.height = 256;
+cacheCanvas.width = 1024;
+cacheCanvas.height = 1024;
 const cacheCanvasCtx = cacheCanvas.getContext('2d');
 
 const moves = [null, null];

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -1028,6 +1028,7 @@ const _makeRig = () => {
             map: texture,
             side: THREE.DoubleSide,
             transparent: true,
+            alphaTest: 0.5,
           });
           const mesh = new THREE.Mesh(geometry, material);
           mesh.frustumCulled = false;


### PR DESCRIPTION
Fixes the reality tabs in-world keyboard enter key edge case: alpha testing and cache canvas size being too small to compute the key mesh image.

![ml_20190112_16 05 44](https://user-images.githubusercontent.com/6926057/51078516-0cef1500-1684-11e9-9dea-b34bbc092286.jpg)
