### PR TITLE
Meshing example polygon offset

### DIFF
--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -83,6 +83,9 @@
       const terrainMeshes = [];
       const terrainMaterial = new THREE.MeshPhongMaterial({
         color: 0x666666,
+        polygonOffset: true,
+        polygonOffsetFactor: -1,
+        polygonOffsetUnits: -1,
       });
       const _getTerrainMesh = meshId => {
         let terrainMesh = terrainMeshes.find(terrainMesh => terrainMesh.meshId === meshId);


### PR DESCRIPTION
Because reality tabs not clip depth to the real world, the meshing reality tab manifests z-fighting since it's using the exact same meshing data.

We fix this z-fighting by adding a polygon offset to the meshing example terrain material.