### PR TITLE
Meshing wireframe

### DIFF
--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -84,7 +84,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.2 + (1.0 - edgeFactor()) * 0.8) * (1.0 - gl_FragCoord.z/gl_FragCoord.w));
+            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.5 + (1.0 - edgeFactor()) * 0.5) * (1.0 - gl_FragCoord.z/gl_FragCoord.w));
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -84,7 +84,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.2 + (1.0 - edgeFactor()) * 0.8) * pow(1.0 - gl_FragCoord.z/gl_FragCoord.w, 0.5));
+            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.2 + (1.0 - edgeFactor()) * 0.8) * (1.0 - gl_FragCoord.z/gl_FragCoord.w));
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -70,8 +70,9 @@
             } else {
               vBC = vec3(0.0, 0.0, 1.0);
             }
-            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-            vPosition = gl_Position.xyz;
+            vec4 modelViewPosition = modelViewMatrix * vec4(position, 1.0);
+            vPosition = modelViewPosition.xyz;
+            gl_Position = projectionMatrix * modelViewPosition;
           }
         `,
         fragmentShader: `\
@@ -79,7 +80,7 @@
           varying vec3 vBC;
 
           vec3 color = vec3(0.984313725490196, 0.5490196078431373, 0.0);
-          vec3 lightDirection = normalize(vec3(1.0));
+          vec3 lightDirection = vec3(0.0, 0.0, 1.0);
 
           float edgeFactor() {
             vec3 d = fwidth(vBC);
@@ -92,13 +93,13 @@
             vec3 xTangent = dFdx( vPosition );
             vec3 yTangent = dFdy( vPosition );
             vec3 faceNormal = normalize( cross( xTangent, yTangent ) );
-            float lightFactor = 0.5 + dot(faceNormal, lightDirection) * 0.5;
+            float lightFactor = pow(dot(faceNormal, lightDirection), 2.0);
             gl_FragColor = vec4(color * barycentricFactor * lightFactor, 1.0);
           }
         `,
         polygonOffset: true,
         polygonOffsetFactor: -1,
-        polygonOffsetUnits: -1,
+        polygonOffsetUnits: -4,
       });
       const _getTerrainMesh = meshId => {
         let terrainMesh = terrainMeshes.find(terrainMesh => terrainMesh.meshId === meshId);

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -9,7 +9,7 @@
   <body>
   <script src="three.js"></script>
   <script>
-    let container, scene, camera, display, model, controllerMeshes;
+    let container, scene, camera, display, model;
     let mesher = null;
 
     const localVector = new THREE.Vector3();
@@ -17,23 +17,6 @@
     const localEuler = new THREE.Euler();
     const localMatrix = new THREE.Matrix4();
     const localFloat32Array = new Float32Array(16);
-
-    const controllerGeometry = new THREE.BoxBufferGeometry(0.1, 0.2, 0.01);
-    const controllerMaterial = new THREE.MeshPhongMaterial({
-      color: 0x4caf50,
-    });
-    const _makeControllerMesh = (x = 0, y = 0, z = 0, qx = 0, qy = 0, qz = 0, qw = 1) => {
-      const mesh = new THREE.Mesh(controllerGeometry, controllerMaterial);
-      mesh.position.set(x, y, z);
-      mesh.quaternion.set(qx, qy, qz, qw);
-      // mesh.matrix.compose(mesh.position, mesh.quaternion, mesh.scale);
-      mesh.updateMatrix();
-      mesh.updateMatrixWorld();
-      mesh.matrixAutoUpdate = false;
-      mesh.frustumCulled = false;
-      return mesh;
-    };
-    const _getControllerIndex = inputSource => inputSource.handedness === 'left' ? 0 : 1;
 
     const numCubes = 100;
     const cubeSize = 0.2;
@@ -59,14 +42,6 @@
       const directionalLight = new THREE.DirectionalLight(0xFFFFFF, 1);
       directionalLight.position.set(1, 1, 1);
       scene.add(directionalLight);
-
-      controllerMeshes = [
-        _makeControllerMesh(-0.1),
-        _makeControllerMesh(0.1),
-      ];
-      controllerMeshes.forEach(controllerMesh => {
-        scene.add(controllerMesh);
-      });
 
       renderer = new THREE.WebGLRenderer({
         antialias: true,
@@ -276,23 +251,6 @@
         );
         model.updateMatrixWorld();
       }
-      if (renderer.vr.enabled) {
-        for (let i = 0; i < controllerMeshes.length; i++) {
-          controllerMeshes[i].visible = false;
-        }
-
-        const inputSources = display.session.getInputSources();
-        for (let i = 0; i < inputSources.length; i++) {
-          const inputSource = inputSources[i];
-          const pose = frame.getInputPose(inputSource);
-
-          const controllerIndex = _getControllerIndex(inputSource);
-          const controllerMesh = controllerMeshes[controllerIndex];
-          controllerMesh.matrix.fromArray(pose.targetRay.transformMatrix);
-          controllerMesh.updateMatrixWorld(true);
-          controllerMesh.visible = true;
-        }
-      }
 
       renderer.render(scene, renderer.vr.enabled ? renderer.vr.getCamera(camera) : camera);
     }
@@ -307,18 +265,6 @@
         exclusive: true,
       });
       display.session = session;
-
-      session.onselect = e => {
-        const controllerIndex = e.inputSource.handedness === 'left' ? 0 : 1;
-        const controllerMesh = controllerMeshes[controllerIndex];
-        controllerMesh.matrixWorld.decompose(controllerMesh.position, controllerMesh.quaternion, controllerMesh.scale);
-
-        const objectMesh = _makeControllerMesh(
-          controllerMesh.position.x, controllerMesh.position.y, controllerMesh.position.z,
-          controllerMesh.quaternion.x, controllerMesh.quaternion.y, controllerMesh.quaternion.z, controllerMesh.quaternion.w,
-        );
-        scene.add(objectMesh);
-      };
 
       // console.log('request first frame');
       session.requestAnimationFrame((timestamp, frame) => {

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -84,7 +84,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.2 + (1.0 - edgeFactor()) * 0.8)) * min((1.0 - gl_FragCoord.z) * 20.0, 1.0);
+            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.2 + (1.0 - edgeFactor()) * 0.8) * pow(1.0 - gl_FragCoord.z/gl_FragCoord.w, 0.5));
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -140,7 +140,7 @@
           positions[baseIndex+7] = positionArray[baseC+1];
           positions[baseIndex+8] = positionArray[baseC+2];
 
-          normals[baseIndex] = normalArray[baseA];
+          /* normals[baseIndex] = normalArray[baseA];
           normals[baseIndex+1] = normalArray[baseA+1];
           normals[baseIndex+2] = normalArray[baseA+2];
           normals[baseIndex+3] = normalArray[baseB];
@@ -148,10 +148,10 @@
           normals[baseIndex+5] = normalArray[baseB+2];
           normals[baseIndex+6] = normalArray[baseC];
           normals[baseIndex+7] = normalArray[baseC+1];
-          normals[baseIndex+8] = normalArray[baseC+2];
+          normals[baseIndex+8] = normalArray[baseC+2]; */
         }
         geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
-        geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3));
+        // geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3));
       };
       const _removeTerrainMesh = terrainMesh => {
         scene.remove(terrainMesh);

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -82,7 +82,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.5 + (1.0 - edgeFactor()) * 0.5), 1.0 - gl_FragCoord.z/gl_FragCoord.w/3.0);
+            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.2 + (1.0 - edgeFactor()) * 0.8), 1.0) * (1.0 - gl_FragCoord.z/gl_FragCoord.w/3.0);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -82,7 +82,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.2 + (1.0 - edgeFactor()) * 0.8), 1.0) * (1.0 - gl_FragCoord.z/gl_FragCoord.w/3.0);
+            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.2 + (1.0 - edgeFactor()) * 0.8), 1.0);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -84,7 +84,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(1.0, 1.0, 1.0, (1.0-edgeFactor())*0.95);
+            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, 0.2 + (1.0 - edgeFactor()) * 0.8);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -82,7 +82,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.5 + (1.0 - edgeFactor()) * 0.5), 1.0);
+            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.5 + (1.0 - edgeFactor()) * 0.5), 1.0 - gl_FragCoord.z/gl_FragCoord.w/3.0);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -82,7 +82,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.5 + (1.0 - edgeFactor()) * 0.5) * (1.0 - gl_FragCoord.z/gl_FragCoord.w));
+            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, 0.5 + (1.0 - edgeFactor()) * 0.5);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -82,7 +82,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, 0.5 + (1.0 - edgeFactor()) * 0.5);
+            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.5 + (1.0 - edgeFactor()) * 0.5), 1.0);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -59,6 +59,7 @@
       const terrainMaterial = new THREE.ShaderMaterial({
         uniforms: {},
         vertexShader: `\
+          varying vec3 vPosition;
           varying vec3 vBC;
           void main() {
             float m = mod(gl_VertexID, 3.0);
@@ -70,10 +71,15 @@
               vBC = vec3(0.0, 0.0, 1.0);
             }
             gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            vPosition = gl_Position.xyz;
           }
         `,
         fragmentShader: `\
+          varying vec3 vPosition;
           varying vec3 vBC;
+
+          vec3 color = vec3(0.984313725490196, 0.5490196078431373, 0.0);
+          vec3 lightDirection = normalize(vec3(1.0));
 
           float edgeFactor() {
             vec3 d = fwidth(vBC);
@@ -82,7 +88,12 @@
           }
 
           void main() {
-            gl_FragColor = vec4(vec3(0.984313725490196, 0.5490196078431373, 0.0) * (0.2 + (1.0 - edgeFactor()) * 0.8), 1.0);
+            float barycentricFactor = (0.2 + (1.0 - edgeFactor()) * 0.8);
+            vec3 xTangent = dFdx( vPosition );
+            vec3 yTangent = dFdy( vPosition );
+            vec3 faceNormal = normalize( cross( xTangent, yTangent ) );
+            float lightFactor = 0.5 + dot(faceNormal, lightDirection) * 0.5;
+            gl_FragColor = vec4(color * barycentricFactor * lightFactor, 1.0);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -56,8 +56,37 @@
       container.appendChild(renderer.domElement);
 
       const terrainMeshes = [];
-      const terrainMaterial = new THREE.MeshPhongMaterial({
-        color: 0x666666,
+      const terrainMaterial = new THREE.ShaderMaterial({
+        uniforms: {},
+        vertexShader: `\
+          attribute vec3 barycentric;
+          varying vec3 vBC;
+          void main() {
+            vBC = barycentric;
+            /* float m = mod(gl_VertexID, 3.0);
+            if (m < 0.5) {
+              vUv = vec2(0.0, 0.0);
+            } else if (m < 1.5) {
+              vUv = vec2(1.0, 1.0);
+            } else {
+              vUv = vec2(1.0, 0.0);
+            } */
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+          }
+        `,
+        fragmentShader: `\
+          varying vec3 vBC;
+
+          float edgeFactor() {
+            vec3 d = fwidth(vBC);
+            vec3 a3 = smoothstep(vec3(0.0), d*1.5, vBC);
+            return min(min(a3.x, a3.y), a3.z);
+          }
+
+          void main() {
+            gl_FragColor = vec4(1.0, 1.0, 1.0, (1.0-edgeFactor())*0.95);
+          }
+        `,
         polygonOffset: true,
         polygonOffsetFactor: -1,
         polygonOffsetUnits: -1,
@@ -76,16 +105,6 @@
       const fakeUint16Array = new Uint16Array(fakeArrayBuffer, 0, 3);
       const _makeTerrainMesh = meshId => {
         const geometry = new THREE.BufferGeometry();
-        const gl = renderer.getContext();
-        const attributes = renderer.getAttributes();
-
-        geometry.addAttribute('position', new THREE.BufferAttribute(fakeFloat32Array, 3));
-        attributes.update(geometry.attributes.position, gl.ARRAY_BUFFER);
-        geometry.addAttribute('normal', new THREE.BufferAttribute(fakeFloat32Array, 3));
-        attributes.update(geometry.attributes.normal, gl.ARRAY_BUFFER);
-        geometry.setIndex(new THREE.BufferAttribute(fakeUint16Array, 1));
-        attributes.update(geometry.index, gl.ELEMENT_ARRAY_BUFFER);
-
         const material = terrainMaterial;
 
         const mesh = new THREE.Mesh(geometry, material);
@@ -94,21 +113,59 @@
         mesh.meshId = meshId;
         return mesh;
       };
-      const _loadTerrainMesh = (terrainMesh, {transformMatrix, positionBuffer, positionCount, normalBuffer, normalCount, indexBuffer, count}) => {
+      const _loadTerrainMesh = (terrainMesh, {transformMatrix, positionArray, positionCount, normalArray, normalCount, indexArray, count}) => {
         terrainMesh.matrix.fromArray(transformMatrix);
         terrainMesh.matrixWorldNeedsUpdate = true;
 
         const {geometry} = terrainMesh;
         const attributes = renderer.getAttributes();
 
-        attributes.get(geometry.attributes.position).buffer = positionBuffer;
-        geometry.attributes.position.count = positionCount / 3;
+        const positions = new Float32Array(count*3);
+        const normals = new Float32Array(count*3);
+        const barycentrics = new Float32Array(count*3);
+        for (let i = 0; i < count; i += 3) {
+          const ai = indexArray[i];
+          const bi = indexArray[i+1];
+          const ci = indexArray[i+2];
 
-        attributes.get(geometry.attributes.normal).buffer = normalBuffer;
-        geometry.attributes.normal.count = normalCount / 3;
+          const baseA = ai*3;
+          const baseB = bi*3;
+          const baseC = ci*3;
 
-        attributes.get(geometry.index).buffer = indexBuffer;
-        geometry.index.count = count / 1;
+          const baseIndex = i*3;
+          positions[baseIndex] = positionArray[baseA];
+          positions[baseIndex+1] = positionArray[baseA+1];
+          positions[baseIndex+2] = positionArray[baseA+2];
+          positions[baseIndex+3] = positionArray[baseB];
+          positions[baseIndex+4] = positionArray[baseB+1];
+          positions[baseIndex+5] = positionArray[baseB+2];
+          positions[baseIndex+6] = positionArray[baseC];
+          positions[baseIndex+7] = positionArray[baseC+1];
+          positions[baseIndex+8] = positionArray[baseC+2];
+
+          normals[baseIndex] = normalArray[baseA];
+          normals[baseIndex+1] = normalArray[baseA+1];
+          normals[baseIndex+2] = normalArray[baseA+2];
+          normals[baseIndex+3] = normalArray[baseB];
+          normals[baseIndex+4] = normalArray[baseB+1];
+          normals[baseIndex+5] = normalArray[baseB+2];
+          normals[baseIndex+6] = normalArray[baseC];
+          normals[baseIndex+7] = normalArray[baseC+1];
+          normals[baseIndex+8] = normalArray[baseC+2];
+
+          barycentrics[baseIndex] = 1;
+          barycentrics[baseIndex+1] = 0;
+          barycentrics[baseIndex+2] = 0;
+          barycentrics[baseIndex+3] = 0;
+          barycentrics[baseIndex+4] = 1;
+          barycentrics[baseIndex+5] = 0;
+          barycentrics[baseIndex+6] = 0;
+          barycentrics[baseIndex+7] = 0;
+          barycentrics[baseIndex+8] = 1;
+        }
+        geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3));
+        geometry.addAttribute('barycentric', new THREE.BufferAttribute(barycentrics, 3));
       };
       const _removeTerrainMesh = terrainMesh => {
         scene.remove(terrainMesh);

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -59,18 +59,16 @@
       const terrainMaterial = new THREE.ShaderMaterial({
         uniforms: {},
         vertexShader: `\
-          attribute vec3 barycentric;
           varying vec3 vBC;
           void main() {
-            vBC = barycentric;
-            /* float m = mod(gl_VertexID, 3.0);
+            float m = mod(gl_VertexID, 3.0);
             if (m < 0.5) {
-              vUv = vec2(0.0, 0.0);
+              vBC = vec3(1.0, 0.0, 0.0);
             } else if (m < 1.5) {
-              vUv = vec2(1.0, 1.0);
+              vBC = vec3(0.0, 1.0, 0.0);
             } else {
-              vUv = vec2(1.0, 0.0);
-            } */
+              vBC = vec3(0.0, 0.0, 1.0);
+            }
             gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
           }
         `,
@@ -122,7 +120,6 @@
 
         const positions = new Float32Array(count*3);
         const normals = new Float32Array(count*3);
-        const barycentrics = new Float32Array(count*3);
         for (let i = 0; i < count; i += 3) {
           const ai = indexArray[i];
           const bi = indexArray[i+1];
@@ -152,20 +149,9 @@
           normals[baseIndex+6] = normalArray[baseC];
           normals[baseIndex+7] = normalArray[baseC+1];
           normals[baseIndex+8] = normalArray[baseC+2];
-
-          barycentrics[baseIndex] = 1;
-          barycentrics[baseIndex+1] = 0;
-          barycentrics[baseIndex+2] = 0;
-          barycentrics[baseIndex+3] = 0;
-          barycentrics[baseIndex+4] = 1;
-          barycentrics[baseIndex+5] = 0;
-          barycentrics[baseIndex+6] = 0;
-          barycentrics[baseIndex+7] = 0;
-          barycentrics[baseIndex+8] = 1;
         }
         geometry.addAttribute('position', new THREE.BufferAttribute(positions, 3));
         geometry.addAttribute('normal', new THREE.BufferAttribute(normals, 3));
-        geometry.addAttribute('barycentric', new THREE.BufferAttribute(barycentrics, 3));
       };
       const _removeTerrainMesh = terrainMesh => {
         scene.remove(terrainMesh);

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -157,12 +157,12 @@
         scene.remove(terrainMesh);
         terrainMesh.geometry.dispose();
       };
-      const _clearTerrainMeshes = () => {
+      /* const _clearTerrainMeshes = () => {
         for (let i = 0; i < terrainMeshes.length; i++) {
           _removeTerrainMesh(terrainMeshes[i]);
         }
         terrainMeshes.length = 0;
-      };
+      }; */
       const _onMesh = updates => {
         for (let i = 0; i < updates.length; i++) {
           const update = updates[i];

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -228,16 +228,6 @@
         }, 100);
       }
 
-      window.addEventListener('keydown', e => {
-        if (e.keyCode === 13) { // enter
-          if (enabled) {
-            _disable();
-          } else {
-            _enable();
-          }
-        }
-      });
-
       renderer.setAnimationLoop(animate);
     }
 

--- a/examples/meshing_ml.html
+++ b/examples/meshing_ml.html
@@ -84,7 +84,7 @@
           }
 
           void main() {
-            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, 0.2 + (1.0 - edgeFactor()) * 0.8);
+            gl_FragColor = vec4(0.984313725490196, 0.5490196078431373, 0, (0.2 + (1.0 - edgeFactor()) * 0.8)) * min((1.0 - gl_FragCoord.z) * 20.0, 1.0);
           }
         `,
         polygonOffset: true,

--- a/examples/meshing_raw_ml.html
+++ b/examples/meshing_raw_ml.html
@@ -1,0 +1,383 @@
+<html>
+  <head>
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+  <script src="three.js"></script>
+  <script>
+    let container, scene, camera, display, model;
+    let mesher = null;
+
+    const localVector = new THREE.Vector3();
+    const localVector2 = new THREE.Vector3();
+    const localEuler = new THREE.Euler();
+    const localMatrix = new THREE.Matrix4();
+    const localFloat32Array = new Float32Array(16);
+
+    const numCubes = 100;
+    const cubeSize = 0.2;
+    const cubeRange = 1;
+    const cubeGeometry = new THREE.BoxBufferGeometry(1, 1, 1);
+
+    function init() {
+      container = document.createElement('div');
+      document.body.appendChild(container);
+
+      scene = new THREE.Scene();
+      scene.matrixAutoUpdate = false;
+      // scene.background = new THREE.Color(0x3B3961);
+
+      camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+      // camera.position.set(0, 1, 0);
+      camera.lookAt(new THREE.Vector3());
+      scene.add(camera);
+
+      const ambientLight = new THREE.AmbientLight(0x808080);
+      scene.add(ambientLight);
+
+      const directionalLight = new THREE.DirectionalLight(0xFFFFFF, 1);
+      directionalLight.position.set(1, 1, 1);
+      scene.add(directionalLight);
+
+      renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: true,
+      });
+      renderer.setPixelRatio(window.devicePixelRatio);
+      renderer.setSize(window.innerWidth, window.innerHeight);
+
+      // window.browser.magicleap.RequestDepthPopulation(true);
+      // renderer.autoClear = false;
+
+      container.appendChild(renderer.domElement);
+
+      const terrainMeshes = [];
+      const terrainMaterial = new THREE.MeshPhongMaterial({
+        color: 0x666666,
+        polygonOffset: true,
+        polygonOffsetFactor: -1,
+        polygonOffsetUnits: -1,
+      });
+      const _getTerrainMesh = meshId => {
+        let terrainMesh = terrainMeshes.find(terrainMesh => terrainMesh.meshId === meshId);
+        if (!terrainMesh) {
+          terrainMesh = _makeTerrainMesh(meshId);
+          terrainMeshes.push(terrainMesh);
+          scene.add(terrainMesh);
+        }
+        return terrainMesh;
+      };
+      const fakeArrayBuffer = new ArrayBuffer(3 * 4);
+      const fakeFloat32Array = new Float32Array(fakeArrayBuffer, 0, 3);
+      const fakeUint16Array = new Uint16Array(fakeArrayBuffer, 0, 3);
+      const _makeTerrainMesh = meshId => {
+        const geometry = new THREE.BufferGeometry();
+        const gl = renderer.getContext();
+        const attributes = renderer.getAttributes();
+
+        geometry.addAttribute('position', new THREE.BufferAttribute(fakeFloat32Array, 3));
+        attributes.update(geometry.attributes.position, gl.ARRAY_BUFFER);
+        geometry.addAttribute('normal', new THREE.BufferAttribute(fakeFloat32Array, 3));
+        attributes.update(geometry.attributes.normal, gl.ARRAY_BUFFER);
+        geometry.setIndex(new THREE.BufferAttribute(fakeUint16Array, 1));
+        attributes.update(geometry.index, gl.ELEMENT_ARRAY_BUFFER);
+
+        const material = terrainMaterial;
+
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.matrixAutoUpdate = false;
+        mesh.frustumCulled = false;
+        mesh.meshId = meshId;
+        return mesh;
+      };
+      const _loadTerrainMesh = (terrainMesh, {transformMatrix, positionBuffer, positionCount, normalBuffer, normalCount, indexBuffer, count}) => {
+        terrainMesh.matrix.fromArray(transformMatrix);
+        terrainMesh.matrixWorldNeedsUpdate = true;
+
+        const {geometry} = terrainMesh;
+        const attributes = renderer.getAttributes();
+
+        attributes.get(geometry.attributes.position).buffer = positionBuffer;
+        geometry.attributes.position.count = positionCount / 3;
+
+        attributes.get(geometry.attributes.normal).buffer = normalBuffer;
+        geometry.attributes.normal.count = normalCount / 3;
+
+        attributes.get(geometry.index).buffer = indexBuffer;
+        geometry.index.count = count / 1;
+      };
+      const _removeTerrainMesh = terrainMesh => {
+        scene.remove(terrainMesh);
+        terrainMesh.geometry.dispose();
+      };
+      const _clearTerrainMeshes = () => {
+        for (let i = 0; i < terrainMeshes.length; i++) {
+          _removeTerrainMesh(terrainMeshes[i]);
+        }
+        terrainMeshes.length = 0;
+      };
+      const _onMesh = updates => {
+        for (let i = 0; i < updates.length; i++) {
+          const update = updates[i];
+          const {id, type} = update;
+
+          if (type === 'new' || type === 'update') {
+            _loadTerrainMesh(_getTerrainMesh(id), update);
+          } else if (type === 'unchanged') {
+            // nothing
+          } else {
+            const index = terrainMeshes.findIndex(terrainMesh => terrainMesh.meshId === id);
+            if (index !== -1) {
+              const terrainMesh = terrainMeshes[index];
+              _removeTerrainMesh(terrainMesh);
+              terrainMeshes.splice(index, 1);
+            }
+          }
+        }
+      };
+
+      if (window.browser && window.browser.magicleap) {
+        mesher = window.browser.magicleap.RequestMeshing();
+        mesher.onmesh = _onMesh;
+      } else {
+        const gl = renderer.getContext();
+
+        const geometryPositions = cubeGeometry.attributes.position.array;
+        const geometryNormals = cubeGeometry.attributes.normal.array;
+        const geometryIndices = cubeGeometry.index.array;
+
+        /* for (let j = 0; j < geometryPositions.length; j += 3) {
+          localVector
+            .fromArray(geometryPositions, j)
+            .multiplyScalar(cubeSize)
+            .toArray(geometryPositions, j);
+        } */
+
+        const positionArray = new Float32Array(new ArrayBuffer(numCubes * geometryPositions.length * Float32Array.BYTES_PER_ELEMENT));
+        const normalArray = new Float32Array(new ArrayBuffer(numCubes * geometryNormals.length * Float32Array.BYTES_PER_ELEMENT));
+        const indexArray = new Uint16Array(new ArrayBuffer(numCubes * geometryIndices.length * Float32Array.BYTES_PER_ELEMENT));
+        for (let i = 0; i < numCubes; i++) {
+          const positionDstOffset = i*geometryPositions.length;
+          const offsetVector = localVector2.set((Math.random()-0.5)*2*cubeRange, (Math.random()-0.5), (Math.random()-0.5)*2*cubeRange);
+          const offsetEuler = localEuler.set((Math.random()-0.5)*2*Math.PI, (Math.random()-0.5)*2*Math.PI, (Math.random()-0.5)*2*Math.PI, 'YXZ');
+          for (let j = 0; j < geometryPositions.length; j += 3) {
+            localVector
+              .fromArray(geometryPositions, j)
+              .multiplyScalar(cubeSize)
+              .applyEuler(offsetEuler)
+              .add(offsetVector)
+              .toArray(positionArray, positionDstOffset + j);
+          }
+
+          const normalDstOffset = i*geometryNormals.length;
+          for (let j = 0; j < geometryNormals.length; j++) {
+            normalArray[normalDstOffset + j] = geometryNormals[j];
+          }
+
+          const indexDstOffset = i*geometryIndices.length;
+          const indexSrcOffset = i*geometryPositions.length/3;
+          for (let j = 0; j < geometryIndices.length; j++) {
+            indexArray[indexDstOffset + j] = geometryIndices[j] + indexSrcOffset;
+          }
+        }
+
+        const transformMatrix = localMatrix
+          .fromArray(window.document.xrOffset.matrix)
+          .getInverse(localMatrix)
+          .toArray(localFloat32Array);
+
+        const positionBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, positionArray, gl.STATIC_DRAW);
+        const positionCount = positionArray.length;
+
+        const normalBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, normalBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, normalArray, gl.STATIC_DRAW);
+        const normalCount = normalArray.length;
+
+        const indexBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexArray, gl.STATIC_DRAW);
+        const count = indexArray.length;
+
+        renderer.state.reset();
+
+        const updates = [
+          {
+            id: 0,
+            type: 'update',
+            transformMatrix,
+            positionArray,
+            positionBuffer,
+            positionCount,
+            normalArray,
+            normalBuffer,
+            normalCount,
+            indexArray,
+            indexBuffer,
+            count,
+          },
+        ];
+        setInterval(() => {
+          _onMesh(updates);
+        }, 100);
+      }
+
+      renderer.setAnimationLoop(animate);
+    }
+
+    function animate(time, frame) {
+      if (model) {
+        const animationTime = 4000;
+        const f = ((Date.now() % animationTime) / animationTime) * (Math.PI * 2);
+        model.quaternion.setFromUnitVectors(
+          new THREE.Vector3(0, 0, 1),
+          new THREE.Vector3(Math.cos(f), 0, Math.sin(f)).normalize()
+        );
+        model.updateMatrixWorld();
+      }
+
+      renderer.render(scene, renderer.vr.enabled ? renderer.vr.getCamera(camera) : camera);
+    }
+
+    init();
+
+    (async () => {
+      console.log('request device');
+      display = await navigator.xr.requestDevice();
+      console.log('request session');
+      const session = await display.requestSession({
+        exclusive: true,
+      });
+      display.session = session;
+
+      // console.log('request first frame');
+      session.requestAnimationFrame((timestamp, frame) => {
+        renderer.vr.setSession(session, {
+          frameOfReferenceType: 'stage',
+        });
+
+        const viewport = session.baseLayer.getViewport(frame.views[0]);
+        const width = viewport.width;
+        const height = viewport.height;
+
+        renderer.setSize(width * 2, height);
+
+        renderer.setAnimationLoop(null);
+
+        renderer.vr.enabled = true;
+        renderer.vr.setDevice(display);
+        renderer.vr.setAnimationLoop(animate);
+
+        console.log('running!');
+      });
+    })();
+
+    (() => {
+      let cameraTracker = null;
+
+      const server = window.browser.http.createServer((req, res) => {
+        console.log('got request', req.url);
+
+        let match;
+        if (req.url === '/') {
+          res.statusCode = 302;
+          res.setHeader('Location', '/examples/camera_client.html');
+          res.end();
+        } else if (match = req.url.match(/\.(html|js)$/)) {
+          fetch('file:///package' + req.url)
+            .then(proxyRes => {
+              if (proxyRes.ok) {
+                return proxyRes.arrayBuffer()
+                  .then(arrayBuffer => {
+                    const type = (() => {
+                      switch (match[1]) {
+                        case 'html': return 'text/html';
+                        case 'js': return 'application/javascript';
+                        default: return 'text/plain';
+                      }
+                    })();
+                    res.setHeader('Content-Type', type);
+
+                    const buffer = Buffer.from(arrayBuffer);
+                    res.end(buffer);
+                  });
+              } else {
+                res.statusCode = proxyRes.status;
+                res.end();
+                return null;
+              }
+            })
+            .catch(err => {
+              console.warn(err.stack);
+              res.statusCode = 500;
+              res.end();
+            });
+        /* } else if (req.url === '/frame') {
+          if (frameData) {
+            console.log('send frame data', typeof frameData, frameData.constructor && frameData.constructor.name, frameData && frameData.length);
+            res.setHeader('Content-Type', 'application/octet-stream');
+            res.end(frameData);
+          } else {
+            res.statusCode = 404;
+            res.end();
+          } */
+        } else {
+          res.statusCode = 404;
+          res.end();
+        }
+      });
+
+      const wss = new window.browser.ws.Server({
+        server,
+      });
+      wss.on('connection', (c, request) => {
+        console.log('open connection');
+
+        if (!cameraTracker) {
+          const _onCameraFrame = e => {
+            // console.log('camera frame', a.length, c.readyState === window.browser.ws.OPEN);
+            const frameData = Buffer.from(e.data);
+
+            for (let i = 0; i < cameraTracker.callbacks.length; i++) {
+              cameraTracker.callbacks[i](frameData);
+            }
+          };
+          window.browser.magicleap.RequestCamera(_onCameraFrame);
+
+          cameraTracker = {
+            callbacks: [],
+          };
+        }
+        
+        const _cameraTrackerCallback = frameData => {
+          if (c.readyState === window.browser.ws.OPEN) {
+            c.send(frameData);
+          }
+        };
+        cameraTracker.callbacks.push(_cameraTrackerCallback);
+
+        c.on('close', () => {
+          console.log('close connection 1');
+          cameraTracker.callbacks.splice(cameraTracker.callbacks.indexOf(_cameraTrackerCallback), 1);
+          console.log('close connection 2');
+          // window.browser.magicleap.CancelCamera(_onCameraFrame);
+          console.log('close connection 3');
+        });
+      });
+
+      server.listen(7999, '0.0.0.0', () => {
+        console.log('listening');
+      });
+      server.on('error', err => {
+        console.warn('server error', err.stack);
+      });
+    })();
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
This adds a barycentric coordinate wireframe meshing example, based on the technique in http://codeflow.org/entries/2012/aug/02/easy-wireframe-display-with-barycentric-coordinates/.

This replaces the nasty and hard-to-view `MeshPhongMaterial` one.