### PR TITLE
VR Gamepads cleanup

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -290,7 +290,6 @@ class VRDisplay extends MRDisplay {
       rightFov,
       frameData,
       stageParameters,
-      handsArray,
     } = update;
 
     if (depthNear !== undefined) {
@@ -322,10 +321,6 @@ class VRDisplay extends MRDisplay {
     }
     if (stageParameters !== undefined) {
       this.stageParameters.copy(stageParameters);
-    }
-    if (handsArray !== undefined) {
-      this._frameData.hands[0].set(handsArray[0]);
-      this._frameData.hands[1].set(handsArray[1]);
     }
   }
 }

--- a/src/VR.js
+++ b/src/VR.js
@@ -36,8 +36,6 @@ class VRFrameData {
     this.rightProjectionMatrix = this.leftProjectionMatrix.slice();
     this.rightViewMatrix = this.leftViewMatrix.slice();
     this.pose = new VRPose();
-
-    VRFrameData.nonstandard.init.call(this);
   }
 
   copy(frameData) {
@@ -46,14 +44,8 @@ class VRFrameData {
     this.rightProjectionMatrix.set(frameData.rightProjectionMatrix);
     this.rightViewMatrix.set(frameData.rightViewMatrix);
     this.pose.copy(frameData.pose);
-
-    VRFrameData.nonstandard.copy.call(this, frameData);
   }
 }
-VRFrameData.nonstandard = {
-  init() {},
-  copy() {},
-};
 class GamepadButton {
   constructor() {
      this.value = 0;
@@ -121,8 +113,6 @@ class Gamepad {
     this.hapticActuators = [new GamepadHapticActuator(this)];
 
     this.ontriggerhapticpulse = null;
-
-    Gamepad.nonstandard.init.call(this);
   }
 
   copy(gamepad) {
@@ -132,14 +122,8 @@ class Gamepad {
     }
     this.pose.copy(gamepad.pose);
     this.axes.set(gamepad.axes);
-
-    Gamepad.nonstandard.copy.call(this, gamepad);
   }
 }
-Gamepad.nonstandard = {
-  init() {},
-  copy() {},
-};
 class VRStageParameters {
   constructor() {
     // new THREE.Matrix4().compose(new THREE.Vector3(0, 0, 0), new THREE.Quaternion(), new THREE.Vector3(1, 1, 1)).toArray(new Float32Array(16))
@@ -417,10 +401,6 @@ class FakeVRDisplay extends MRDisplay {
 
       this._frameData.pose.set(this.position, this.quaternion);
     }
-
-    const globalGamepads = getAllGamepads();
-    gamepads[0] = globalGamepads[0];
-    gamepads[1] = globalGamepads[1];
   }
 
   requestPresent() {
@@ -484,19 +464,11 @@ class FakeVRDisplay extends MRDisplay {
 
 const createVRDisplay = () => new FakeVRDisplay();
 
-const gamepads = [null, null];
+const gamepads =  [
+  new Gamepad('left', 0),
+  new Gamepad('right', 1),
+];
 const getGamepads = () => gamepads;
-
-let allGamepads = null;
-const getAllGamepads = () => {
-  if (allGamepads === null) { // defer so constructor overrides can be declared
-    allGamepads = [
-      new Gamepad('left', 0),
-      new Gamepad('right', 1),
-    ];
-  }
-  return allGamepads;
-};
 
 module.exports = {
   MRDisplay,
@@ -509,5 +481,4 @@ module.exports = {
   GamepadButton,
   createVRDisplay,
   getGamepads,
-  getAllGamepads,
 };

--- a/src/core.js
+++ b/src/core.js
@@ -373,14 +373,6 @@ class MLDisplay extends MRDisplay {
     }
   }
 
-  getGeometry(positions, normals, indices, metrics) {
-    if (this._context) {
-      return this._context.stageGeometry.getGeometry(positions, normals, indices, metrics);
-    } else {
-      return 0;
-    }
-  }
-
   update(update) {
     const {
       depthNear,

--- a/src/core.js
+++ b/src/core.js
@@ -35,7 +35,6 @@ const {
   Gamepad,
   GamepadButton,
   getGamepads,
-  getAllGamepads,
 } = require('./VR.js');
 
 const BindingsModule = require('./bindings');
@@ -319,86 +318,12 @@ class Screen {
   set availHeight(availHeight) {}
 }
 
-const handEntrySize = (1 + (5 * 5)) * (3 + 3);
-const maxNumPlanes = 32 * 3;
-const planeEntrySize = 3 + 4 + 2 + 1;
-VRFrameData.nonstandard = {
-  init() {
-    this.hands = [
-      new Float32Array(handEntrySize),
-      new Float32Array(handEntrySize),
-    ];
-    this.planes = new Float32Array(maxNumPlanes * planeEntrySize);
-    this.numPlanes = 0;
-  },
-  copy(frameData) {
-    for (let i = 0; i < this.hands.length; i++) {
-      this.hands[i].set(frameData.hands[i]);
-    }
-    this.planes.set(frameData.planes);
-    this.numPlanes = frameData.numPlanes;
-  },
-};
-class GamepadGesture {
-  constructor() {
-    this.position = new Float32Array(3);
-    this.gesture = null;
-  }
-
-  copy(gesture) {
-    this.position.set(gesture.position);
-    this.gesture = gesture.gesture;
-  }
-}
-Gamepad.nonstandard = {
-  init() {
-    this.gesture = new GamepadGesture();
-  },
-  copy(gamepad) {
-    this.gesture.copy(gamepad.gesture);
-  },
-};
-
 const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
 const localQuaternion = new THREE.Quaternion();
 const localMatrix = new THREE.Matrix4();
-/* class ARDisplay extends MRDisplay {
-  constructor(window) {
-    super('AR', window);
-
-    this._viewMatrix = new Float32Array(16);
-    this._projectionMatrix = new Float32Array(16);
-
-    const _resize = () => {
-      this._width = window.innerWidth / 2;
-      this._height = window.innerHeight;
-    };
-    window.top.on('resize', _resize);
-    const _updatearframe = (viewMatrix, projectionMatrix) => {
-      this._viewMatrix.set(viewMatrix);
-      this._projectionMatrix.set(projectionMatrix);
-    };
-    window.top.on('updatearframe', _updatearframe);
-
-    this._cleanups.push(() => {
-      window.top.removeListener('resize', _resize);
-      window.top.removeListener('updatearframe', _updatearframe);
-    });
-  }
-
-  getFrameData(frameData) {
-    const hmdMatrix = localMatrix.fromArray(this._viewMatrix);
-    hmdMatrix.decompose(localVector, localQuaternion, localVector2);
-    frameData.pose.set(localVector, localQuaternion);
-
-    frameData.leftViewMatrix.set(this._viewMatrix);
-    frameData.rightViewMatrix.set(this._viewMatrix);
-
-    frameData.leftProjectionMatrix.set(this._projectionMatrix);
-    frameData.rightProjectionMatrix.set(this._projectionMatrix);
-  }
-} */
+const maxNumPlanes = 32 * 3;
+const planeEntrySize = 3 + 4 + 2 + 1;
 class MLDisplay extends MRDisplay {
   constructor() {
     super('ML');
@@ -1771,19 +1696,12 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     const _updateGamepads = newGamepads => {
       if (newGamepads !== undefined) {
         const gamepads = getGamepads();
-        const allGamepads = getAllGamepads();
 
         if (newGamepads[0]) {
-          gamepads[0] = allGamepads[0];
           gamepads[0].copy(newGamepads[0]);
-        } else {
-          gamepads[0] = null;
         }
         if (newGamepads[1]) {
-          gamepads[1] = allGamepads[1];
           gamepads[1].copy(newGamepads[1]);
-        } else {
-          gamepads[1] = null;
         }
       }
     };
@@ -1921,7 +1839,6 @@ exokit.download = (src, dst) => exokit.load(src, {
       accept();
     });
   }));
-exokit.getAllGamepads = getAllGamepads;
 exokit.THREE = THREE;
 exokit.setArgs = newArgs => {
   GlobalContext.args = newArgs;

--- a/src/index.js
+++ b/src/index.js
@@ -1188,7 +1188,7 @@ const _bindWindow = (window, newWindowCb) => {
     total: 0,
   };
   const TIMESTAMP_FRAMES = DEFAULT_FPS;
-  const [leftGamepad, rightGamepad] = core.getAllGamepads();
+  const [leftGamepad, rightGamepad] = core.getGamepads();
   const gamepads = [null, null];
   const frameData = new window.VRFrameData();
   const stageParameters = new window.VRStageParameters();

--- a/src/index.js
+++ b/src/index.js
@@ -1188,8 +1188,8 @@ const _bindWindow = (window, newWindowCb) => {
     total: 0,
   };
   const TIMESTAMP_FRAMES = DEFAULT_FPS;
-  const [leftGamepad, rightGamepad] = core.getGamepads();
-  const gamepads = [null, null];
+  const gamepads = core.getGamepads();
+  const [leftGamepad, rightGamepad] = gamepads;
   const frameData = new window.VRFrameData();
   const stageParameters = new window.VRStageParameters();
   let timeout = null;
@@ -1373,10 +1373,8 @@ const _bindWindow = (window, newWindowCb) => {
           leftGamepad.axes[i] = localGamepadArray[11+i];
         }
         leftGamepad.buttons[1].value = leftGamepad.axes[2]; // trigger
-
-        gamepads[0] = leftGamepad;
       } else {
-        gamepads[0] = null;
+        leftGamepad.connected = false;
       }
 
       vrPresentState.system.GetControllerState(1, localGamepadArray);
@@ -1404,10 +1402,8 @@ const _bindWindow = (window, newWindowCb) => {
           rightGamepad.axes[i] = localGamepadArray[11+i];
         }
         rightGamepad.buttons[1].value = rightGamepad.axes[2]; // trigger
-
-        gamepads[1] = rightGamepad;
       } else {
-        gamepads[1] = null;
+        rightGamepad.connected = false;
       }
 
       if (vrPresentState.lmContext) {
@@ -1502,8 +1498,6 @@ const _bindWindow = (window, newWindowCb) => {
         leftGamepad.buttons[0].pressed = leftPadPushed;
         controllersArrayIndex += 3;
 
-        gamepads[0] = leftGamepad;
-
         rightGamepad.connected = controllersArray[controllersArrayIndex] > 0;
         controllersArrayIndex++;
         rightGamepad.pose.position.set(controllersArray.slice(controllersArrayIndex, controllersArrayIndex + 3));
@@ -1538,8 +1532,6 @@ const _bindWindow = (window, newWindowCb) => {
         rightGamepad.buttons[0].touched = rightPadTouched;
         rightGamepad.buttons[0].pressed = rightPadPushed;
         controllersArrayIndex += 3;
-
-        gamepads[1] = rightGamepad;
 
         // update ml frame
         window.top.updateVrFrame({

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ const {THREE} = core;
 const nativeBindingsModulePath = path.join(__dirname, 'native-bindings.js');
 const nativeBindings = require(nativeBindingsModulePath);
 
+const {getGamepads} = require('./VR.js');
+
 const GlobalContext = require('./GlobalContext');
 GlobalContext.commands = [];
 
@@ -1188,7 +1190,7 @@ const _bindWindow = (window, newWindowCb) => {
     total: 0,
   };
   const TIMESTAMP_FRAMES = DEFAULT_FPS;
-  const gamepads = core.getGamepads();
+  const gamepads = getGamepads();
   const [leftGamepad, rightGamepad] = gamepads;
   const frameData = new window.VRFrameData();
   const stageParameters = new window.VRStageParameters();


### PR DESCRIPTION
WebVR is deprecated, and there is some code in there to support WebXR-type APIs like hands tracking and planes detection which did not have a place back then.

Since now we've entirely moved platform-specific things under the `window.browser` namespace, we can delete this code and simplify the render loop in the process.