### PR TITLE
Reality tabs home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "cross-env": "^5.2.0",
     "css": "^2.2.3",
     "events": "^3.0.0",
-    "exokit-home": "0.0.70",
     "fake-indexeddb": "^2.0.4",
     "fault-zone": "0.0.20",
     "he": "^1.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1729,7 +1729,7 @@ const _prepare = () => Promise.all([
 const _start = () => {
   let {url: u} = args;
   if (!u && args.home) {
-    u = 'file://' + path.join(path.dirname(require.resolve('exokit-home')), 'index.html') + (args.tag ? ('?t=' + encodeURIComponent(args.tab)) : '');
+    u = 'file://' + path.join(__dirname, 'examples', 'realitytabs.html');
   }
   if (u) {
     if (u === '.') {

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,6 @@ const args = (() => {
         'headless',
       ],
       string: [
-        'tab',
         'webgl',
         'xr',
         'size',
@@ -57,7 +56,6 @@ const args = (() => {
         v: 'version',
         h: 'home',
         l: 'log',
-        t: 'tab',
         w: 'webgl',
         x: 'xr',
         p: 'performance',
@@ -77,9 +75,8 @@ const args = (() => {
     return {
       version: minimistArgs.version,
       url: minimistArgs._[0] || '',
-      home: minimistArgs.home || !!minimistArgs.tab,
+      home: minimistArgs.home,
       log: minimistArgs.log,
-      tab: minimistArgs.tab,
       webgl: minimistArgs.webgl || '2',
       xr: minimistArgs.xr || 'all',
       performance: !!minimistArgs.performance,


### PR DESCRIPTION
Makes `realitytabs.html` the home page when you open exokit on desktop.

Previously we were using `exokit-home` which did a similar thing but also much more (skinning, file upload prototype, etc.). This page is simpler and gives parity with Android AR modes.