### PR TITLE
Update OpenVR

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "native-browser-deps-windows": "0.0.1",
     "native-canvas-deps": "0.0.50",
     "native-graphics-deps": "0.0.20",
-    "native-openvr-deps": "0.0.17",
+    "native-openvr-deps": "0.0.18",
     "native-video-deps": "0.0.30",
     "node-ipc": "^9.1.1",
     "node-localstorage": "^1.3.1",


### PR DESCRIPTION
This updates Exokit's OpenVR bindings to `1.1.3b`. Steam recently updated their code and Oculus shim support broke and being up to date is probably the first step of fixing that.

Attempted fix for https://github.com/webmixedreality/exokit/issues/742.