### PR TITLE
N-API support

### DIFF
--- a/deps/exokit-bindings/egl/src/egl.cc
+++ b/deps/exokit-bindings/egl/src/egl.cc
@@ -11,13 +11,6 @@ thread_local NATIVEwindow *currentWindow = nullptr;
 int lastX = 0, lastY = 0; // XXX track this per-window
 std::unique_ptr<Nan::Persistent<Function>> eventHandler;
 
-void NAN_INLINE(CallEmitter(int argc, Local<Value> argv[])) {
-  if (eventHandler && !(*eventHandler).IsEmpty()) {
-    Local<Function> eventHandlerFn = Nan::New(*eventHandler);
-    eventHandlerFn->Call(Nan::Null(), argc, argv);
-  }
-}
-
 void Initialize() {
   EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 

--- a/deps/exokit-bindings/windowsystem/include/windowsystem.h
+++ b/deps/exokit-bindings/windowsystem/include/windowsystem.h
@@ -73,6 +73,8 @@ NAN_METHOD(ResizeRenderTarget);
 NAN_METHOD(DestroyRenderTarget);
 void ComposeLayers(WebGLRenderingContext *gl, const std::vector<LayerSpec> &layers);
 NAN_METHOD(ComposeLayers);
+NAN_METHOD(GetEventLoop);
+NAN_METHOD(SetEventLoop);
 void Decorate(Local<Object> target);
 
 }

--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -808,12 +808,28 @@ NAN_METHOD(ComposeLayers) {
   }
 }
 
+thread_local uv_loop_t *eventLoop;
+NAN_METHOD(GetEventLoop) {
+  info.GetReturnValue().Set(pointerToArray(eventLoop));
+}
+NAN_METHOD(SetEventLoop) {
+  if (info[0]->IsArray()) {
+    Local<Array> loopArray = Local<Array>::Cast(info[0]);
+    uv_loop_t *loop = (uv_loop_t *)arrayToPointer(loopArray);
+    eventLoop = loop;
+  } else {
+    Nan::ThrowError("WindowSystem::SetEventLoop: invalid arguments");
+  }
+}
+
 void Decorate(Local<Object> target) {
   Nan::SetMethod(target, "createRenderTarget", CreateRenderTarget);
   Nan::SetMethod(target, "resizeRenderTarget", ResizeRenderTarget);
   Nan::SetMethod(target, "destroyRenderTarget", DestroyRenderTarget);
   // Nan::SetMethod(target, "renderPlane", RenderPlane);
   Nan::SetMethod(target, "composeLayers", ComposeLayers);
+  Nan::SetMethod(target, "getEventLoop", GetEventLoop);
+  Nan::SetMethod(target, "setEventLoop", SetEventLoop);
 }
 
 }

--- a/main.cpp
+++ b/main.cpp
@@ -17,7 +17,7 @@
 using namespace v8;
 
 namespace node {
-  extern std::map<std::string, void *> dlibs;
+  extern std::map<std::string, std::pair<void *, bool>> dlibs;
   int Start(int argc, char* argv[]);
 }
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bugsnag": "^2.4.3",
     "cross-env": "^5.2.0",
     "css": "^2.2.3",
-    "event-loop-native": "0.0.7",
+    "event-loop-native": "0.0.8",
     "events": "^3.0.0",
     "exokit-home": "0.0.70",
     "fake-indexeddb": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bugsnag": "^2.4.3",
     "cross-env": "^5.2.0",
     "css": "^2.2.3",
-    "event-loop-native": "0.0.6",
+    "event-loop-native": "0.0.7",
     "events": "^3.0.0",
     "exokit-home": "0.0.70",
     "fake-indexeddb": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bugsnag": "^2.4.3",
     "cross-env": "^5.2.0",
     "css": "^2.2.3",
+    "event-loop-native": "0.0.4",
     "events": "^3.0.0",
     "exokit-home": "0.0.70",
     "fake-indexeddb": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bugsnag": "^2.4.3",
     "cross-env": "^5.2.0",
     "css": "^2.2.3",
-    "event-loop-native": "0.0.4",
+    "event-loop-native": "0.0.6",
     "events": "^3.0.0",
     "exokit-home": "0.0.70",
     "fake-indexeddb": "^2.0.4",

--- a/scripts/gen-dlibs-h.js
+++ b/scripts/gen-dlibs-h.js
@@ -5,8 +5,8 @@ const find = require('find');
 const dirname = process.argv[2];
 
 find.file(/\.node$/, dirname, files => {
+  const header = `#include <v8.h>\n#include <node_api.h>\n\n`;
   let decls = `extern "C" {\n`;
-  let decls_napi = `extern "C" {\n`;
   let registers = `inline void registerDlibs(std::map<std::string, void *> &dlibs) {\n`;
 
   for (let i = 0; i < files.length; i++) {
@@ -27,9 +27,9 @@ find.file(/\.node$/, dirname, files => {
             decls += `  void ${registerName}(Local<Object> exports, Local<Value> module, Local<Context> context);\n`;
             registers += `  dlibs["/package${relpath}${binName}.node"] = (void *)&${registerName};\n`;
           } else if (npmName.replace(/-/g, '_') + '_napi' === binName) {
-            const registerName = `node_register_module_${binName})_napi`;
-            decls_napi += `  napi_value ${registerName}(napi_env env, napi_value exports);\n`;
-            registers += `  dlibs_napi["/package${relpath}${binName}.node"] = (void *)&${registerName};\n`;
+            const registerName = `node_register_module_${binName}`;
+            decls += `  napi_value ${registerName}(napi_env env, napi_value exports);\n`;
+            registers += `  dlibs["/package${relpath}${binName}.node"] = (void *)&${registerName};\n`;
           }
         }
       }
@@ -37,10 +37,9 @@ find.file(/\.node$/, dirname, files => {
   }
   
   decls += `}\n`;
-  decls_napi += `}\n`;
   registers += `}\n`;
   
+  console.log(header);
   console.log(decls);
-  console.log(decls_napi);
   console.log(registers);
 });

--- a/scripts/gen-dlibs-h.js
+++ b/scripts/gen-dlibs-h.js
@@ -7,7 +7,7 @@ const dirname = process.argv[2];
 find.file(/\.node$/, dirname, files => {
   const header = `#include <v8.h>\n#include <node_api.h>\n\n`;
   let decls = `extern "C" {\n`;
-  let registers = `inline void registerDlibs(std::map<std::string, void *> &dlibs) {\n`;
+  let registers = `inline void registerDlibs(std::map<std::string, std::pair<void *, bool>> &dlibs) {\n`;
 
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
@@ -25,11 +25,11 @@ find.file(/\.node$/, dirname, files => {
           if (npmName.replace(/-/g, '_') === binName) {
             const registerName = `node_register_module_${binName}`;
             decls += `  void ${registerName}(Local<Object> exports, Local<Value> module, Local<Context> context);\n`;
-            registers += `  dlibs["/package${relpath}${binName}.node"] = (void *)&${registerName};\n`;
+            registers += `  dlibs["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, false);\n`;
           } else if (npmName.replace(/-/g, '_') + '_napi' === binName) {
             const registerName = `node_register_module_${binName}`;
             decls += `  napi_value ${registerName}(napi_env env, napi_value exports);\n`;
-            registers += `  dlibs["/package${relpath}${binName}.node"] = (void *)&${registerName};\n`;
+            registers += `  dlibs_napi["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, true);\n`;
           }
         }
       }

--- a/scripts/gen-dlibs-h.js
+++ b/scripts/gen-dlibs-h.js
@@ -20,17 +20,15 @@ find.file(/\.node$/, dirname, files => {
           const match = relpath.match(/\/node_modules\/([^\/]+)/);
           return match && match[1];
         })();
-        if (npmName) {
-          // ignore incompatible modules
-          if (npmName.replace(/-/g, '_') === binName) {
-            const registerName = `node_register_module_${binName}`;
-            decls += `  void ${registerName}(Local<Object> exports, Local<Value> module, Local<Context> context);\n`;
-            registers += `  dlibs["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, false);\n`;
-          } else if (npmName.replace(/-/g, '_') + '_napi' === binName) {
-            const registerName = `node_register_module_${binName}`;
-            decls += `  napi_value ${registerName}(napi_env env, napi_value exports);\n`;
-            registers += `  dlibs["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, true);\n`;
-          }
+        // ignore incompatible modules
+        if (!npmName || npmName.replace(/-/g, '_') === binName) {
+          const registerName = `node_register_module_${binName}`;
+          decls += `  void ${registerName}(Local<Object> exports, Local<Value> module, Local<Context> context);\n`;
+          registers += `  dlibs["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, false);\n`;
+        } else if (npmName && npmName.replace(/-/g, '_') + '_napi' === binName) {
+          const registerName = `node_register_module_${binName}`;
+          decls += `  napi_value ${registerName}(napi_env env, napi_value exports);\n`;
+          registers += `  dlibs["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, true);\n`;
         }
       }
     }

--- a/scripts/gen-dlibs-h.js
+++ b/scripts/gen-dlibs-h.js
@@ -29,7 +29,7 @@ find.file(/\.node$/, dirname, files => {
           } else if (npmName.replace(/-/g, '_') + '_napi' === binName) {
             const registerName = `node_register_module_${binName}`;
             decls += `  napi_value ${registerName}(napi_env env, napi_value exports);\n`;
-            registers += `  dlibs_napi["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, true);\n`;
+            registers += `  dlibs["/package${relpath}${binName}.node"] = std::pair<void *, bool>((void *)&${registerName}, true);\n`;
           }
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,6 @@ if (require.main === module) {
 // const cwd = process.cwd();
 // process.chdir(__dirname); // needed for global bin to find libraries
 
-console.log('event loop native 1');
-const eventLoopNative = require('event-loop-native');
-console.log('event loop native 2', eventLoopNative);
-
 const events = require('events');
 const {EventEmitter} = events;
 const path = require('path');
@@ -52,6 +48,14 @@ const {THREE} = core;
 
 const nativeBindingsModulePath = path.join(__dirname, 'native-bindings.js');
 const nativeBindings = require(nativeBindingsModulePath);
+
+console.log('event loop native 1');
+const eventLoopNative = require('event-loop-native');
+console.log('event loop native 2', eventLoopNative);
+nativeBindings.nativeWindow.setEventLoop(eventLoopNative);
+console.log('event loop native 3');
+const eventLoopNative2 = nativeBindings.nativeWindow.getEventLoop();
+console.log('event loop native 4', eventLoopNative2);
 
 const {getGamepads} = require('./VR.js');
 // const {_setNativeBindingsModule} = require('./Window');

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,10 @@ if (require.main === module) {
 // const cwd = process.cwd();
 // process.chdir(__dirname); // needed for global bin to find libraries
 
+console.log('event loop native 1');
+const eventLoopNative = require('event-loop-native');
+console.log('event loop native 2', eventLoopNative);
+
 const events = require('events');
 const {EventEmitter} = events;
 const path = require('path');

--- a/src/index.js
+++ b/src/index.js
@@ -49,13 +49,8 @@ const {THREE} = core;
 const nativeBindingsModulePath = path.join(__dirname, 'native-bindings.js');
 const nativeBindings = require(nativeBindingsModulePath);
 
-console.log('event loop native 1');
 const eventLoopNative = require('event-loop-native');
-console.log('event loop native 2', eventLoopNative);
 nativeBindings.nativeWindow.setEventLoop(eventLoopNative);
-console.log('event loop native 3');
-const eventLoopNative2 = nativeBindings.nativeWindow.getEventLoop();
-console.log('event loop native 4', eventLoopNative2);
 
 const {getGamepads} = require('./VR.js');
 // const {_setNativeBindingsModule} = require('./Window');


### PR DESCRIPTION
For tracking the event loop (`uv_event_loop_t`), the official `node` solution is to use N-API. Many parts of exokit depend on getting the correct event loop, especially with user parellelization landing soon.

The problem is that exokit's native module build system for mobile hasn't supported N-API. This PR fixes that by extending the `dlib` require hijack to handle the case of N-API registration for modules.

Additionally, this PR exposes an `event-loop-native` module to get the event loop for the current thread, and adds a `windowsystem` getter/setter for tracking it. These are not used for anything yet, but the idea is that every module sensitive to threading/context will use the event loop computed and latched there.