### PR TITLE
Force msvs_version=2017

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "node-gyp build",
     "debug": "ndb",
-    "install": "node ./scripts/preinstall.js && node-gyp rebuild",
+    "install": "node ./scripts/preinstall.js && node-gyp configure --msvs_version=2017 && node-gyp rebuild",
     "lint": "eslint src tests",
     "rebuild": "shx rm -rf node_modules && npm cache clean --force && npm install",
     "serve": "serve examples",


### PR DESCRIPTION
On windows, exokit can only be built with MSVS 2017.

There's leeway in minor versions of compiler and libs, but 2017 is a hard requirement because the prebuilt binary libraries are linked against 2017, and MSVS 2015 cannot read/link the newer ABI symbols when building.

Therefore, this PR is to locally request MSVS 2017 from `node-gyp` in case there is a conflict. This is not a global option; it should only apply to `npm install`ing Exokit.