### PR TITLE
Clean up reality tabs tutorial

### DIFF
--- a/examples/tutorial.html
+++ b/examples/tutorial.html
@@ -102,8 +102,8 @@
       // scene.background = new THREE.Color(0x3B3961);
 
       camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
-      // camera.position.set(0, 1, 0);
-      camera.lookAt(new THREE.Vector3());
+      camera.position.set(0, 1, 2);
+      // camera.lookAt(new THREE.Vector3());
       scene.add(camera);
 
       const ambientLight = new THREE.AmbientLight(0x808080);

--- a/examples/tutorial.html
+++ b/examples/tutorial.html
@@ -330,32 +330,37 @@
     (async () => {
       console.log('request device');
       display = await navigator.xr.requestDevice();
-      console.log('request session');
-      const session = await display.requestSession({
-        exclusive: true,
-      });
-      display.session = session;
 
-      // console.log('request first frame');
-      session.requestAnimationFrame((timestamp, frame) => {
-        renderer.vr.setSession(session, {
-          frameOfReferenceType: 'stage',
+      if (display) {
+        console.log('request session');
+        const session = await display.requestSession({
+          exclusive: true,
         });
+        display.session = session;
 
-        const viewport = session.baseLayer.getViewport(frame.views[0]);
-        const width = viewport.width;
-        const height = viewport.height;
+        // console.log('request first frame');
+        session.requestAnimationFrame((timestamp, frame) => {
+          renderer.vr.setSession(session, {
+            frameOfReferenceType: 'stage',
+          });
 
-        renderer.setSize(width * 2, height);
+          const viewport = session.baseLayer.getViewport(frame.views[0]);
+          const width = viewport.width;
+          const height = viewport.height;
 
-        renderer.setAnimationLoop(null);
+          renderer.setSize(width * 2, height);
 
-        renderer.vr.enabled = true;
-        renderer.vr.setDevice(display);
-        renderer.vr.setAnimationLoop(animate);
+          renderer.setAnimationLoop(null);
 
-        console.log('running!');
-      });
+          renderer.vr.enabled = true;
+          renderer.vr.setDevice(display);
+          renderer.vr.setAnimationLoop(animate);
+
+          console.log('running!');
+        });
+      } else {
+        renderer.setAnimationLoop(animate);
+      }
     })()
       .catch(err => {
         console.warn(err.stack);

--- a/examples/tutorial.html
+++ b/examples/tutorial.html
@@ -259,8 +259,6 @@
       // renderer.autoClear = false;
 
       container.appendChild(renderer.domElement);
-
-      renderer.setAnimationLoop(animate);
     }
 
     const animationTime = 1000;


### PR DESCRIPTION
Makes the `tutorial.html` that is the first auto-loaded reality tab work outside of the context of WebXR/reality tabs, by just using the THREE.js render loop. This is mostly for testing a baseline render without the reality tabs compositor on top.