### PR TITLE
Remove extraneous libnode.a lib path in binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -531,7 +531,6 @@
             "<!(echo $MLSDK)/lumin/stl/libc++/lib",
             "<!(echo $MLSDK)/lumin/usr/lib",
             "<!(echo $MLSDK)/lib/lumin",
-            "<(module_root_dir)/libnode.a",
             "<(module_root_dir)/node_modules/native-canvas-deps/lib2/magicleap",
             "<(module_root_dir)/node_modules/native-audio-deps/lib2/magicleap",
             "<(module_root_dir)/node_modules/native-video-deps/lib2/magicleap",


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/788.