### PR TITLE
Bugfix DOMContentLoaded event emit

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -169,13 +169,16 @@ function initDocument (document, window) {
 
       body.childNodes = bodyChildNodes;
 
-      document.dispatchEvent(new Event('DOMContentLoaded', {target: document}));
-
       try {
         await GlobalContext._runHtml(document.body, window);
       } catch(err) {
         console.warn(err);
       }
+
+      document.dispatchEvent(new Event('DOMContentLoaded', {
+        target: document,
+        bubbles: true,
+      }));
     } else {
       try {
         await GlobalContext._runHtml(document, window);
@@ -183,7 +186,10 @@ function initDocument (document, window) {
         console.warn(err);
       }
 
-      document.dispatchEvent(new Event('DOMContentLoaded', {target: document}));
+      document.dispatchEvent(new Event('DOMContentLoaded', {
+        target: document,
+        bubbles: true,
+      }));
     }
 
     document.readyState = 'interactive';


### PR DESCRIPTION
Found this in the Babylon.js bootstrap example: https://doc.babylonjs.com/#getting-started

We want the event to bubble, and we also want to run it after the `<body>` script has been executed.