### PR TITLE
[WEBGL2] Re-add decorate gl intercepts

### DIFF
--- a/src/native-bindings.js
+++ b/src/native-bindings.js
@@ -73,7 +73,7 @@ bindings.nativeGl = (nativeGl => {
 bindings.nativeGl2 = (nativeGl2 => {
   function WebGL2RenderingContext(canvas) {
     const gl = new nativeGl2();
-  //  _decorateGlIntercepts(gl);   // this should not be needed; left as comment only
+    _decorateGlIntercepts(gl);
     bindings.nativeGl.onconstruct(gl, canvas);
     return gl;
   }


### PR DESCRIPTION
This was thought not needed, but some of the `webgl-to-opengl` transforms are still necessary to transform WebGL shaders to OpenGL.

Example of a case fixed in Babylon.js:

```
BJS - [13:06:21]: Error: ERROR: 0:2: '' : syntax error: #version directive must occur in a shader before anything else
ERROR: 0:2: '' : illegal order of preprocessor directives
WARNING: 0:20: 'precision' : symbol not available in current GLSL version
WARNING: 0:20: 'highp' : symbol not available in current GLSL version
WARNING: 0:465: 'constructor' : constructing matrix from matrix is allowed from GLSL 1.20 (reserved in GLSL 1.10)


BJS - [13:06:21]: Trying next fallback.
BJS - [13:06:21]: Unable to compile effect:
BJS - [13:06:21]: Uniforms:  world, view, viewProjection, vEyePosition, vLightsType, vAmbientColor, vDiffuseColor, vSpecularColor, vEmissiveColor, vFogInfos, vFogColor, pointSize, vDiffuseInfos, vAmbientInfos, vOpacityInfos, vReflectionInfos, vEmissiveInfos, vSpecularInfos, vBumpInfos, vLightmapInfos, vRefractionInfos, mBones, vClipPlane, vClipPlane2, vClipPlane3, vClipPlane4, diffuseMatrix, ambientMatrix, opacityMatrix, reflectionMatrix, emissiveMatrix, specularMatrix, bumpMatrix, normalMatrix, lightmapMatrix, refractionMatrix, diffuseLeftColor, diffuseRightColor, opacityParts, reflectionLeftColor, reflectionRightColor, emissiveLeftColor, emissiveRightColor, refractionLeftColor, refractionRightColor, vReflectionPosition, vReflectionSize, logarithmicDepthConstant, vTangentSpaceParams, alphaCutOff, vLightData0, vLightDiffuse0, vLightSpecular0, vLightDirection0, vLightFalloff0, vLightGround0, lightMatrix0, shadowsInfo0, depthValues0, diffuseSampler, ambientSampler, opacitySampler, reflectionCubeSampler, reflection2DSampler, emissiveSampler, specularSampler, bumpSampler, lightmapSampler, refractionCubeSampler, refraction2DSampler, shadowSampler0, depthSampler0
BJS - [13:06:21]: Attributes:  position, normal
BJS - [13:06:21]: Error: ERROR: 0:2: '' : syntax error: #version directive must occur in a shader before anything else
ERROR: 0:2: '' : illegal order of preprocessor directives
WARNING: 0:20: 'precision' : symbol not available in current GLSL version
WARNING: 0:20: 'highp' : symbol not available in current GLSL version
WARNING: 0:465: 'constructor' : constructing matrix from matrix is allowed from GLSL 1.20 (reserved in GLSL 1.10)
```