### PR TITLE
Bump window-fetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "vm-one": "0.0.32",
     "webgl-to-opengl": "0.0.12",
     "window-classlist": "0.0.4",
-    "window-fetch": "0.0.9",
+    "window-fetch": "0.0.10",
     "window-selector": "0.0.6",
     "window-worker": "0.0.100",
     "window-xhr": "0.0.23",


### PR DESCRIPTION
This adds support for `file://` urls with query strings in them.