### PR TITLE
Bugfix createRenderTarget max texture

### DIFF
--- a/deps/exokit-bindings/windowsystem/src/windowsystem.cc
+++ b/deps/exokit-bindings/windowsystem/src/windowsystem.cc
@@ -312,6 +312,7 @@ void InitializeLocalGlState(WebGLRenderingContext *gl) {
   }
 }
 
+constexpr GLint MAX_TEXTURE_SIZE = 4096;
 bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint sharedColorTex, GLuint sharedDepthStencilTex, GLuint sharedMsColorTex, GLuint sharedMsDepthStencilTex, GLuint *pfbo, GLuint *pcolorTex, GLuint *pdepthStencilTex, GLuint *pmsFbo, GLuint *pmsColorTex, GLuint *pmsDepthStencilTex) {
   const int samples = 4;
 
@@ -335,9 +336,9 @@ bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, msDepthStencilTex);
     glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
 #ifndef LUMIN
-    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_DEPTH24_STENCIL8, GL_MAX_TEXTURE_SIZE, GL_MAX_TEXTURE_SIZE/2, true);
+    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_DEPTH24_STENCIL8, MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE/2, true);
 #else
-    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_DEPTH24_STENCIL8, GL_MAX_TEXTURE_SIZE, GL_MAX_TEXTURE_SIZE/2, true);
+    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_DEPTH24_STENCIL8, MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE/2, true);
 #endif
     // glFramebufferTexture2DMultisampleEXT(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, msDepthStencilTex, 0, samples);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, msDepthStencilTex, 0);
@@ -350,9 +351,9 @@ bool CreateRenderTarget(WebGLRenderingContext *gl, int width, int height, GLuint
     glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, msColorTex);
     glTexParameteri(GL_TEXTURE_2D_MULTISAMPLE, GL_TEXTURE_MAX_LEVEL, 0);
 #ifndef LUMIN
-    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_RGBA8, GL_MAX_TEXTURE_SIZE, GL_MAX_TEXTURE_SIZE/2, true);
+    glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_RGBA8, MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE/2, true);
 #else
-    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_RGBA8, GL_MAX_TEXTURE_SIZE, GL_MAX_TEXTURE_SIZE/2, true);
+    glTexStorage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, samples, GL_RGBA8, MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE/2, true);
 #endif
     // glFramebufferTexture2DMultisampleEXT(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, msColorTex, 0, samples);
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, msColorTex, 0);

--- a/src/index.js
+++ b/src/index.js
@@ -496,10 +496,11 @@ if (nativeBindings.nativeVr) {
         const lmContext = vrPresentState.lmContext || (nativeBindings.nativeLm && new nativeBindings.nativeLm());
 
         let {width: halfWidth, height} = system.GetRecommendedRenderTargetSize();
-        const maxTextureSize = 4096;
-        if (halfWidth > maxTextureSize) {
-          const factor = halfWidth / maxTextureSize;
-          halfWidth = 4096;
+        const MAX_TEXTURE_SIZE = 4096;
+        const MAX_TEXTURE_SIZE_HALF = MAX_TEXTURE_SIZE/2;
+        if (halfWidth > MAX_TEXTURE_SIZE_HALF) {
+          const factor = halfWidth / MAX_TEXTURE_SIZE_HALF;
+          halfWidth = MAX_TEXTURE_SIZE_HALF;
           height = Math.floor(height / factor);
         }
         const width = halfWidth * 2;

--- a/src/index.js
+++ b/src/index.js
@@ -495,7 +495,13 @@ if (nativeBindings.nativeVr) {
 
         const lmContext = vrPresentState.lmContext || (nativeBindings.nativeLm && new nativeBindings.nativeLm());
 
-        const {width: halfWidth, height} = system.GetRecommendedRenderTargetSize();
+        let {width: halfWidth, height} = system.GetRecommendedRenderTargetSize();
+        const maxTextureSize = 4096;
+        if (halfWidth > maxTextureSize) {
+          const factor = halfWidth / maxTextureSize;
+          halfWidth = 4096;
+          height = Math.floor(height / factor);
+        }
         const width = halfWidth * 2;
         xrState.renderWidth[0] = halfWidth;
         xrState.renderHeight[0] = height;


### PR DESCRIPTION
This PR fixes the fact that `GL_MAX_TEXTURE_SIZE` is _not_ a measurement in pixels, but rather a constant that gets you the platform max texture size in pixels.

This was not noticed because `GL_MAX_TEXTURE_SIZE` is ~`3000` as a constant, so it was a reasonable "maximum texture size". However , when used on a supersampled VR device that recommends higher framebuffer sizes (manifested on HTC Vive), this is insufficient to hold the full framebuffer.

We therefore increase this value to 4K. Additionally, we cap the recommended render target size from the platform to 4K -- note that this is _already_ additionally supersampled.

We cannot go nuts with this setting, because as we get into larger framebuffer sizes the memory cost grows quadratically, while providing no quality improvement on today's headsets.