### PR TITLE
Add WebGL getContextAttributes method

### DIFF
--- a/deps/exokit-bindings/webglcontext/include/webgl.h
+++ b/deps/exokit-bindings/webglcontext/include/webgl.h
@@ -306,6 +306,8 @@ public:
   static NAN_METHOD(GetVertexAttrib);
   static NAN_METHOD(GetSupportedExtensions);
   static NAN_METHOD(GetExtension);
+  static NAN_METHOD(GetContextAttributes);
+  
   static NAN_METHOD(CheckFramebufferStatus);
 
   static NAN_METHOD(CreateVertexArray);

--- a/deps/exokit-bindings/webglcontext/src/webgl.cc
+++ b/deps/exokit-bindings/webglcontext/src/webgl.cc
@@ -1127,6 +1127,8 @@ std::pair<Local<Object>, Local<FunctionTemplate>> WebGLRenderingContext::Initial
   Nan::SetMethod(proto, "getShaderPrecisionFormat", glCallWrap<GetShaderPrecisionFormat>);
   Nan::SetMethod(proto, "getSupportedExtensions", glCallWrap<GetSupportedExtensions>);
   Nan::SetMethod(proto, "getExtension", glCallWrap<GetExtension>);
+  Nan::SetMethod(proto, "getContextAttributes", glCallWrap<GetContextAttributes>);
+
   Nan::SetMethod(proto, "checkFramebufferStatus", glCallWrap<CheckFramebufferStatus>);
 
   Nan::SetMethod(proto, "createVertexArray", glCallWrap<CreateVertexArray>);
@@ -4993,6 +4995,18 @@ NAN_METHOD(WebGLRenderingContext::GetExtension) {
   } else {
     info.GetReturnValue().Set(Null(Isolate::GetCurrent()));
   }
+}
+
+NAN_METHOD(WebGLRenderingContext::GetContextAttributes) {
+  Local<Object> result = Object::New(Isolate::GetCurrent());
+  result->Set(JS_STR("alpha"), JS_BOOL(true));
+  result->Set(JS_STR("antialias"), JS_BOOL(true));
+  result->Set(JS_STR("depth"), JS_BOOL(true));
+  result->Set(JS_STR("failIfMajorPerformanceCaveat"), JS_BOOL(false));
+  result->Set(JS_STR("premultipliedAlpha"), JS_BOOL(true));
+  result->Set(JS_STR("preserveDrawingBuffer"), JS_BOOL(false));
+  result->Set(JS_STR("stencil"), JS_BOOL(false));
+  info.GetReturnValue().Set(result);
 }
 
 NAN_METHOD(WebGLRenderingContext::CheckFramebufferStatus) {


### PR DESCRIPTION
Implements https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getContextAttributes.

Outputs static data for now.