### PR TITLE
Add missing document.referrer

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -37,6 +37,7 @@ function initDocument (document, window) {
   document.body = body;
   document.location = window.location;
   document.cookie = '';
+  document.referrer = '';
   document.createElement = tagName => {
     tagName = tagName.toUpperCase();
     const HTMLElementTemplate = window[symbols.htmlTagsSymbol][tagName];


### PR DESCRIPTION
We don't track referrers, but Sketchfab references this and crashes otherwise.