### PR TITLE
Make window global undefined

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -398,6 +398,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
 
     global.process = undefined;
     global.setImmediate = undefined;
+    window.global = undefined;
   })();`;
 
   for (const k in EventEmitter.prototype) {


### PR DESCRIPTION
Some libraries check for this to see if they are running inside of node. We want that to seem like it's not the case.

Note that this PR requires some deeper testing on Magic Leap -- IIRC this may interfere with the way the SSL js implementation references `global`.