### PR TITLE
Add replace argument feature

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -1544,6 +1544,10 @@ class HTMLLinkElement extends HTMLLoadableElement {
 }
 module.exports.HTMLLinkElement = HTMLLinkElement;
 
+const _mapUrl = (u, window) => {
+  const v = window[symbols.optionsSymbol].replacements[u];
+  return v !== undefined ? v : u;
+};
 class HTMLScriptElement extends HTMLLoadableElement {
   constructor(attrs = [], value = '', location = null) {
     super('SCRIPT', attrs, value, location);
@@ -1640,7 +1644,7 @@ class HTMLScriptElement extends HTMLLoadableElement {
   loadRunNow() {
     this.readyState = 'loading';
     
-    const url = this.src;
+    const url = _mapUrl(this.src, this.ownerDocument.defaultView);
     
     return this.ownerDocument.resources.addResource((onprogress, cb) => {
       this.ownerDocument.defaultView.fetch(url)

--- a/src/core.js
+++ b/src/core.js
@@ -314,6 +314,7 @@ const exokit = (s = '', options = {}) => {
   options.baseUrl = options.baseUrl || options.url;
   options.dataPath = options.dataPath || __dirname;
   options.args = options.args || {};
+  options.replacements = options.replacements || {};
   return _makeWindowWithDocument(s, options);
 };
 exokit.load = (src, options = {}) => {
@@ -321,6 +322,7 @@ exokit.load = (src, options = {}) => {
     src = 'http://' + src;
   }
   options.args = options.args || {};
+  options.replacements = options.replacements || {};
 
   let redirectCount = 0;
   const _fetchTextFollow = src => fetch(src, {
@@ -370,6 +372,7 @@ exokit.load = (src, options = {}) => {
         baseUrl,
         dataPath: options.dataPath,
         args: options.args,
+        replacements: options.replacements,
       });
     });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ const args = (() => {
         'xr',
         'size',
         'download',
+        'replace',
       ],
       alias: {
         v: 'version',
@@ -93,7 +94,8 @@ const args = (() => {
         t: 'tab',
         q: 'quit',
         b: 'blit',
-        r: 'require',
+        r: 'replace',
+        u: 'require',
         n: 'headless',
         d: 'download',
       },
@@ -112,6 +114,7 @@ const args = (() => {
       tab: minimistArgs.tab,
       quit: minimistArgs.quit,
       blit: minimistArgs.blit,
+      replace: Array.isArray(minimistArgs.replace) ? minimistArgs.replace : ((minimistArgs.replace !== undefined) ? [minimistArgs.replace] : []),
       require: minimistArgs.require,
       headless: minimistArgs.headless,
       download: minimistArgs.download !== undefined ? (minimistArgs.download || path.join(process.cwd(), 'downloads')) : undefined,
@@ -1767,9 +1770,23 @@ const _start = () => {
     if (u && !url.parse(u).protocol) {
       u = 'file://' + path.resolve(process.cwd(), u);
     }
+    const replacements = (() => {
+      const result = {};
+      for (let i = 0; i < args.replace.length; i++) {
+        const replaceArg = args.replace[i];
+        const replace = replaceArg.split(' ');
+        if (replace.length === 2) {
+          result[replace[0]] = 'file://' + path.resolve(process.cwd(), replace[1]);
+        } else {
+          console.warn(`invalid replace argument: ${replaceArg}`);
+        }
+      }
+      return result;
+    })();
     return core.load(u, {
       dataPath,
       args,
+      replacements,
     });
   } else {
     let window = null;


### PR DESCRIPTION
This PR add support for the `-r <srcUrl> <dstFile>` argument, which allows live remapping of file paths loaded in `<script>` tags. If a script tag attempts to load `srcUrl`, it will transparently load `dstFile` instead.

The main use case for this is to dynamically debug sites, freely rewriting their Javascript in a local file copy.