### PR TITLE
Bump window-xhr version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "window-fetch": "0.0.10",
     "window-selector": "0.0.6",
     "window-worker": "0.0.100",
-    "window-xhr": "0.0.23",
+    "window-xhr": "0.0.25",
     "worker-native": "0.0.4",
     "ws": "^6.1.2"
   },


### PR DESCRIPTION
This fixes `XMLHttpRequest` non-standard HTTPS port handling, as used in `webpack-dev-server`.