### PR TITLE
Add origin header to WebSocket constructor

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -644,6 +644,11 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   })(XMLHttpRequest);
   window.WebSocket = (Old => {
     class WebSocket extends Old {
+      constructor(url, protocols) {
+        super(url, protocols, {
+          Origin: location.origin,
+        });
+      }
       emit(type, event) {
         if (type === 'message') {
           event = utils._normalizePrototype(event, window);


### PR DESCRIPTION
This fixes the default `webpack-dev-server` origin security check.