### PR TITLE
Increase UA fakeness

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -428,8 +428,8 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   });
   window.history = new History(location.href);
   window.navigator = {
-    userAgent: `MixedReality (Exokit ${GlobalContext.version})`,
-    vendor: 'MixedReality',
+    userAgent: `Mozilla/5.0 (OS) AppleWebKit/999.0 (KHTML, like Gecko) Chrome/999.0.0.0 Safari/999.0 Exokit/${GlobalContext.version}`,
+    vendor: 'Exokit',
     platform: os.platform(),
     hardwareConcurrency: os.cpus().length,
     appCodeName: 'Mozilla',


### PR DESCRIPTION
Running [`detect-browser`](https://www.npmjs.com/package/detect-browser) on the old Exokit user agent, which is actually Exokit, results in a non-detected browser, which ends up crashing apps that use this detection. Notably, Hubs.

Therefore this PR increases the lengths we go to pretend to be Chrome, which passes the check. We still claim to be Exokit so it's not a complete lie.