### PR TITLE
Bump window-xhr version

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "window-fetch": "0.0.10",
     "window-selector": "0.0.6",
     "window-worker": "0.0.100",
-    "window-xhr": "0.0.25",
+    "window-xhr": "0.0.28",
     "worker-native": "0.0.4",
     "ws": "^6.1.2"
   },


### PR DESCRIPTION
Adds XMLHttpRequest `gzip` support, needed for Hubs.