### PR TITLE
Bugfix children events emits

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -582,10 +582,10 @@ class Element extends Node {
     });
     this.on('children', (addedNodes, removedNodes, previousSibling, nextSiblings) => {
       for (let i = 0; i < addedNodes.length; i++) {
-        addedNodes[i].emit('attached');
+        addedNodes[i]._emit('attached');
       }
       for (let i = 0; i < removedNodes.length; i++) {
-        removedNodes[i].emit('removed');
+        removedNodes[i]._emit('removed');
       }
     });
   }


### PR DESCRIPTION
The `emit` event conflicts with A-Frame. We alraedy have infrastructure for getting around this in the form of `_emit`, but it wasn't being used for the `added` and `removed` node events.