### PR TITLE
Add fake vr display supportsSession()

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -493,6 +493,10 @@ class FakeVRDisplay extends VRDisplay {
     return Promise.resolve(session);
   }
   
+  supportsSession() {
+    return Promise.resolve(null);
+  }
+  
   get layers() {
     return this._layers;
   }

--- a/src/XR.js
+++ b/src/XR.js
@@ -46,7 +46,7 @@ class XRDevice {
     
     this._layers = [];
   }
-  supportsSession({exclusive = false, outputContext = null} = {}) {
+  supportsSession() {
     return Promise.resolve(null);
   }
   requestSession({exclusive = false, outputContext = null} = {}) {


### PR DESCRIPTION
The `supportsSession` method was missing from the fake vr display emulation. Some experiences depend on this and so didn't work in emulated XR mode.