### PR TITLE
Add navigator.mediaDevices.enumerateDevices

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -452,6 +452,18 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
           return Promise.reject(new Error('constraints not met'));
         }
       },
+      enumerateDevices() {
+        let deviceIds = 0;
+        let groupIds = 0;
+        return Promise.resolve([
+          {
+            deviceId: (++deviceIds) + '',
+            groupId: (++groupIds) + '',
+            kind: 'audioinput',
+            label: 'Microphone',
+          },
+        ]);
+      },
     },
     getVRDisplaysSync() {
       const result = [];


### PR DESCRIPTION
Adds the `enumerateDevices` method. This was needed to get Hubs booting.