### PR TITLE
Bugfix AnalyserNode set fftSize

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.12.1",
-    "native-audio-deps": "0.0.55",
+    "native-audio-deps": "0.0.56",
     "native-browser-deps": "0.0.16",
     "native-browser-deps-linux": "0.0.4",
     "native-browser-deps-macos": "0.0.1",


### PR DESCRIPTION
We previously set the WebAudio `AnalyserNode` `fftSize` by reconstructing the node. This reattachment was bugged and unnecessary; we can simply reset the analyser at the LabSound level.

- Rebuild Labsound with new `lab::AnalyserNode::setFFTSize` method
- Use `setFFTSize` instead of reconstructing the `AnalyserNode`

This was manifested in Supersaber/Beatsaber Viewer.