### PR TITLE
History module version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fake-indexeddb": "^2.0.4",
     "fault-zone": "0.0.20",
     "he": "^1.1.1",
-    "history": "^4.7.2",
+    "history": "^4.9.0",
     "hterm-repl": "0.0.10",
     "isolator": "0.0.9",
     "leapmotion": "0.0.4",

--- a/src/History.js
+++ b/src/History.js
@@ -1,5 +1,5 @@
 const {EventEmitter} = require('events');
-const createMemoryHistory = require('history/createMemoryHistory').default;
+const {createMemoryHistory} = require('history');
 
 class History extends EventEmitter {
   constructor(u) {


### PR DESCRIPTION
The builds started failing at https://travis-ci.org/webmixedreality/exokit/jobs/506998028, due to a `history` module update.

Goring forward (+ a slight API update) fixes the problem.