### PR TITLE
WebRTC feature detection

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -431,6 +431,17 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     },
   });
   window.history = new History(location.href);
+  function getUserMedia(constraints) {
+    if (constraints.audio) {
+      return Promise.resolve(new MicrophoneMediaStream());
+    } else if (constraints.video) {
+      const dev = new VideoDevice();
+      dev.constraints = constraints.video;
+      return Promise.resolve(dev);
+    } else {
+      return Promise.reject(new Error('constraints not met'));
+    }
+  }
   window.navigator = {
     userAgent: `Mozilla/5.0 (OS) AppleWebKit/999.0 (KHTML, like Gecko) Chrome/999.0.0.0 Safari/999.0 Exokit/${GlobalContext.version}`,
     vendor: 'Exokit',
@@ -441,17 +452,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
     appVersion: '5.0',
     language: 'en-US',
     mediaDevices: {
-      getUserMedia(constraints) {
-        if (constraints.audio) {
-          return Promise.resolve(new MicrophoneMediaStream());
-        } else if (constraints.video) {
-          const dev = new VideoDevice();
-          dev.constraints = constraints.video;
-          return Promise.resolve(dev);
-        } else {
-          return Promise.reject(new Error('constraints not met'));
-        }
-      },
+      getUserMedia,
       enumerateDevices() {
         let deviceIds = 0;
         let groupIds = 0;

--- a/src/Window.js
+++ b/src/Window.js
@@ -466,7 +466,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         ]);
       },
     },
-    webkitGetUserMedia, // for feature detection
+    webkitGetUserMedia: getUserMedia, // for feature detection
     getVRDisplaysSync() {
       const result = [];
       if (GlobalContext.fakeVrDisplayEnabled) {

--- a/src/Window.js
+++ b/src/Window.js
@@ -466,6 +466,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
         ]);
       },
     },
+    webkitGetUserMedia, // for feature detection
     getVRDisplaysSync() {
       const result = [];
       if (GlobalContext.fakeVrDisplayEnabled) {
@@ -775,6 +776,7 @@ const _makeWindow = (options = {}, parent = null, top = null) => {
   window.MediaStream = class MediaStream {};
   
   window.RTCPeerConnection = RTCPeerConnection;
+  window.webkitRTCPeerConnection = RTCPeerConnection; // for feature detection
   window.RTCSessionDescription = RTCSessionDescription;
   window.RTCIceCandidate = RTCIceCandidate;
   


### PR DESCRIPTION
The [`webrtc-adapter`](https://www.npmjs.com/package/webrtc-adapter) module feature detects browsers based on legacy globals exposure presence. If we don't pretend to be Chrome (which we are most like), we will get treated as Safari and get shimmed with incompatible RTC hacks.

Therefore this PR adds `webkitGetUserMedia` and `webkitRTCPeerConnection` globals exposure (with no functionality change) so that we are better detected as Chrome WebRTC-capable.