### PR TITLE
Bugfix decimal CSS parsing

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -393,7 +393,10 @@ const _makeStyleProxy = el => {
         const rule = rules[j];
         const {declarations} = rule;
         for (let k = 0; k < declarations.length; k++) {
-          const {property, value} = declarations[k];
+          let {property, value} = declarations[k];
+          if (/^\.[0-9]+[a-z]*$/i.test(value)) {
+            value = '0' + value;
+          }
           style[property] = value;
         }
       }


### PR DESCRIPTION
This fixes `el.style.opacity` (among others) from returning `.[0-9]+`, when it should be `0.[0-9]+`.

This shouldn't matter because exokit doesn't try to render CSS. However, jQuery _does_ use this behavior for feature testing. Therefore to get it right, we need to play ball and clean up these values.