### PR TITLE
Bugfix immediate context termination

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,8 +283,13 @@ nativeBindings.nativeGl.onconstruct = (gl, canvas) => {
 
       contexts.splice(contexts.indexOf(gl), 1);
 
-      if (!contexts.some(context => nativeWindow.isVisible(context.getWindowHandle()))) { // no more windows
-        process.exit();
+      const _hasMoreContexts = () => contexts.some(context => nativeWindow.isVisible(context.getWindowHandle()));
+      if (!_hasMoreContexts()) {
+        setImmediate(() => { // give time to create a replacement context
+          if (!_hasMoreContexts()) {
+            process.exit();
+          }
+        });
       }
     })(gl.destroy);
 


### PR DESCRIPTION
In Exokit, the lifetime of the app is tied to the presence of GL contexts (windows). When the last window exits, we exit the app.

Unfortunately this leads to the corner case of:
- app creates context
- app deletes context
- app creates replacement context in the same tick

If we exit in step 2, the app will shut down despite the intent of the author being to continue.

Therefore this PR adds a short tick period for the app to create a replacement context and continue. If the app does not do this, we exit as normal.