### PR TITLE
Add Range setStart/setEnd methods

### DIFF
--- a/src/Document.js
+++ b/src/Document.js
@@ -368,5 +368,8 @@ class Range extends DocumentFragment {
     fragment.innerHTML = str;
     return fragment;
   }
+
+  setStart() {}
+  setEnd() {}
 }
 module.exports.Range = Range;


### PR DESCRIPTION
These are set to do nothing, since we do not care about `Range` in XR land. However, sites using CodeMirror break without these.