### PR TITLE
Linux: add Ffmpeg libx264 linkage

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -217,6 +217,7 @@
                     '-lavdevice',
                     '-lswscale',
                     '-lswresample',
+                    '-lx264',
                     '-lopenvr_api',
                     '-luuid',
                     '-lXcursor',


### PR DESCRIPTION
This is  in the FFmpeg binaries but was not being linked in `binding.gyp`.