### PR TITLE
[ML] Faster debugging

### DIFF
--- a/scripts/debug-ml.sh
+++ b/scripts/debug-ml.sh
@@ -6,4 +6,4 @@ cd "$(dirname "$0")"
 
 source ./version-ml.sh
 
-cmd.exe /c "$MLSDK_WIN/debug.cmd" --deploy-mpk ../build/magicleap/exokit.mpk ../build/magicleap/program-device/release_lumin_clang-3.8_aarch64/program-device --env "ARGS=node --experimental-worker . $@"
+cmd.exe /c "$MLSDK_WIN/debug.cmd" -p com.webmr.exokit ../build/magicleap/program-device/release_lumin_clang-3.8_aarch64/program-device --env "ARGS=node --experimental-worker . $@"


### PR DESCRIPTION
Updates the magic leap debug start script to _not_ upload the MPK before debugging and instead just launch the exokit app. There is already an `install.sh` script to perform the install.

The result is a faster Magic Leap debugging flow.