### PR TITLE
[ML] Fix wrong mutex used to cover

### DIFF
--- a/deps/exokit-bindings/magicleap/src/magicleap.cc
+++ b/deps/exokit-bindings/magicleap/src/magicleap.cc
@@ -162,7 +162,7 @@ void RunResInMainThread(uv_async_t *handle) {
   for (;;) {
     std::function<void()> resCb;
     {
-      std::lock_guard<std::mutex> lock(reqMutex);
+      std::lock_guard<std::mutex> lock(resMutex);
 
       if (resCbs.size() > 0) {
         resCb = resCbs.front();


### PR DESCRIPTION
This is a bug in the Magic Leap binding; it was discovered in Oculus bringup (https://github.com/webmixedreality/exokit/issues/146).

This fixes what would be a possible rare crash case.