### PR TITLE
Migrate Exokit links from "webmr.io" to "exokit.org"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-[slack]: https://exokit.slack.com/join/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q 
+[slack]: https://exokit.slack.com/join/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q
 [stackoverflow]: http://stackoverflow.com/questions/tagged/exokit
 
 Interested in contributing? As an open source project, we'd appreciate any help
@@ -25,13 +25,13 @@ from your questions too.
 2. Specify the version of Exokit in which the bug occurred.
 3. Specify information about your browser and system (e.g., "Exokit v0.0.420 on OS X")
 4. Describe the problem in detail (i.e., what happened and what you expected would happen).
-5. If possible, provide a small test case with [CodePen](http://codepen.io), a link to your application, and/or a screenshot. 
+5. If possible, provide a small test case with [CodePen](http://codepen.io), a link to your application, and/or a screenshot.
 
-# Contribute Code to Exokit 
+# Contribute Code to Exokit
 
 [exokit]: https://github.com/webmixedreality/exokit/
-[easy]: https://github.com/webmixedreality/exokit/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy 
-[hard]: https://github.com/webmixedreality/exokit/issues?q=is%3Aopen+is%3Aissue+label%3Ahard 
+[easy]: https://github.com/webmixedreality/exokit/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy
+[hard]: https://github.com/webmixedreality/exokit/issues?q=is%3Aopen+is%3Aissue+label%3Ahard
 [pr]: https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github
 [ssh]: https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/
 
@@ -51,7 +51,7 @@ under the [MIT License](LICENSE).
 
 # Share your Work
 
-1. Create something awesome using Exokit. 
+1. Create something awesome using Exokit.
 2. Publish your work to Github (and GitHub pages) so everyone can learn from your work.
 3. Share it on [Slack](https://exokit.slack.com), Twitter, etc.
 4. For bonus points, write and publish a case study to explain how you built it.
@@ -73,7 +73,7 @@ that might be useful in the documentation, request to add it!
 If a Glitch example needs to be updated for whatever reason, we can remix the
 Glitch and update the `src` URL.
 
-# Help Your Fellow Exokit users 
+# Help Your Fellow Exokit users
 
 ## On Slack
 
@@ -89,7 +89,7 @@ Glitch and update the `src` URL.
 
 # Curate and Make Efforts Known
 
-We round up all the cool stuff happening with Exokit on the [blog](https://webmr.io/blog).
+We round up all the cool stuff happening with Exokit on the [blog](https://exokit.org/blog).
 
 # Spread the Word
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <h1 align="center">Exokit</h1>
-<p align="center"><a href="https://webmr.io" target="_blank"><img width="300" height="300" alt="Exokit" src="icon.png"/></a></p>
+<p align="center"><a href="https://exokit.org" target="_blank"><img width="300" height="300" alt="Exokit" src="icon.png"/></a></p>
 <p align="center"><b>:dark_sunglasses: Native VR and AR engine for JavaScript 🦖</b></p>
 
 <p align="center">
-  <a href="https://join.slack.com/t/exokit/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q"><img src="https://img.shields.io/badge/slack-join-green.svg?logo=slack&longCache=true&style=flat"></a> 
+  <a href="https://join.slack.com/t/exokit/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q"><img src="https://img.shields.io/badge/slack-join-green.svg?logo=slack&longCache=true&style=flat"></a>
   <a href="https://github.com/webmixedreality/exokit/releases"><img src="https://img.shields.io/github/downloads/webmixedreality/exokit/total.svg"></a>
   <a href="https://www.npmjs.com/package/exokit"><img src="https://img.shields.io/npm/v/exokit.svg"></a>
   <a href="https://travis-ci.org/modulesio/exokit-windows"><img src="https://travis-ci.org/modulesio/exokit-windows.svg?branch=master"></a>
@@ -12,9 +12,9 @@
 </p>
 
 <div align="center">
-  <a href="https://webmr.io">Site</a>
+  <a href="https://exokit.org">Site</a>
   &mdash;
-  <a href="https://webmr.io/docs/">Docs</a>
+  <a href="https://exokit.org/docs/">Docs</a>
   &mdash;
   <a href="https://discordapp.com/invite/Apk6cZN">Discord</a>
   &mdash;
@@ -30,11 +30,11 @@
 <a href="https://youtu.be/cd_DEwCDF6U"><img alt="Hands Reality Tab" target="_blank" src="assets/hands_ml.gif" height="190" width="32%"></a>
 <a href="https://youtu.be/b-UKSg0QCRE"><img alt="Live Reload Magic Leap" target="_blank" src="assets/reload_ml.gif" height="190" width="32%"></a>
 <a href="https://youtu.be/O1xA1r5SZUM"><img alt="Tutorial Reality Tab" target="_blank" src="assets/tutorial_rt.gif" height="190" width="32%"></a>
-  
+
 <a href="https://www.youtube.com/watch?v=m_QntqZmd_Q"><img alt="Reality Projection with HTC Vive and Magic Leap" target="_blank" src="assets/realityprojection.gif" height="190" width="32%"></a>
 <a href="https://youtu.be/i0MXRCNkdB4"><img alt="Emukit" target="_blank" src="assets/emukit.gif" height="190" width="32%"></a>
-<a href="https://webmr.io/"><img alt="Various Exokit Apps" target="_blank" src="assets/screenshots.gif" height="190" width="32%"></a>
-  
+<a href="https://exokit.org/"><img alt="Various Exokit Apps" target="_blank" src="assets/screenshots.gif" height="190" width="32%"></a>
+
 *Find more examples [here](https://github.com/webmixedreality/exokit/tree/master/examples) and on [YouTube](https://www.youtube.com/channel/UC87Q7_5ooY8FSLwOec52ZPQ).*
 
 
@@ -88,13 +88,13 @@ This project **enables developers to build XR experiences using the same code th
 
 ## Quickstart
 
-### Desktop 
+### Desktop
 <h4><a href="https://get.webmr.io">Download for current OS</a></h4>
 
 #### Run a WebXR site (desktop)
 
 ```sh
-exokit https://emukit.webmr.io/ # start Emukit in Exokit
+exokit https://aframe.io/a-painter/ # start A-Painter in Exokit
 ```
 
 ### Magic Leap
@@ -185,7 +185,7 @@ For questions and support, [ask on StackOverflow](https://stackoverflow.com/ques
 
 - [Join our Slack](https://join.slack.com/t/exokit/shared_invite/enQtNDI3NjcxNzYwMDIxLWU2NmFmOTEzMzk4NWNiYjRhMjVkYzcyNjg5YjUyMzZkYWM1ZGI4M2IwYWZiMjNlMTJjMDlkM2U3Y2JiNTc2M2Q) for development.
 - [Join our Discord](https://discord.gg/Apk6cZN) for hanging out.
-- [Follow @webmixedreality on Twitter](https://twitter.com/webmixedreality) for updates. 
+- [Follow @webmixedreality on Twitter](https://twitter.com/webmixedreality) for updates.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This project **enables developers to build XR experiences using the same code th
 ## Quickstart
 
 ### Desktop
-<h4><a href="https://get.webmr.io">Download for current OS</a></h4>
+<h4><a href="https://get.exokit.org">Download for current OS</a></h4>
 
 #### Run a WebXR site (desktop)
 
@@ -99,7 +99,7 @@ exokit https://aframe.io/a-painter/ # start A-Painter in Exokit
 
 ### Magic Leap
 
-<h4><a href="https://get.webmr.io/magicleap">Download for Magic Leap</a></h4>
+<h4><a href="https://get.exokit.org/magicleap">Download for Magic Leap</a></h4>
 
 #### Run (Magic Leap device)
 

--- a/examples/realitytabs.html
+++ b/examples/realitytabs.html
@@ -87,7 +87,7 @@ let serversLoading = false;
 let serverConnectedUrl = null;
 
 const DEFAULT_URL = 'http://lol.com';
-const DEFAULT_REGISTRY_URL = 'http://xrmp.webmr.io:9001';
+const DEFAULT_REGISTRY_URL = 'http://xrmp.exokit.org:9001';
 const DEFAULT_SKIN_URL = 'skin2.png';
 const RAY_COLOR = 0x44c2ff;
 const RAY_HIGHLIGHT_COLOR = new THREE.Color(RAY_COLOR).multiplyScalar(0.5).getHex();

--- a/scripts/exokit-install.sh
+++ b/scripts/exokit-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # usage:
-#   wget -qO- https://get.webmr.io | sudo sh
+#   wget -qO- https://get.exokit.org | sudo sh
 # This script will download and install Exokit in /usr/lib
 
 echo "Exokit $VERSION install script"
@@ -11,4 +11,4 @@ if [ -x "$(command -v apt-get)" ]; then
 fi
 cd /tmp
 rm -Rf /usr/local/bin/exokit /usr/local/lib/exokit
-wget -O- https://get.webmr.io/linux-bin | tar -zxf - --directory /usr/local
+wget -O- https://get.exokit.org/linux-bin | tar -zxf - --directory /usr/local


### PR DESCRIPTION
PR to change webmr.io links to exokit.org. The following references to webmr.io are not included:

### XRMP server:
- https://github.com/webmixedreality/exokit/blob/39c6754c3886295c48fb004aa6d915b3f7ae4023/examples/realitytabs.html#L90

  
### Install links (get.webmr.io):
- https://github.com/webmixedreality/exokit/blob/d88b56b1c7faea3b50921b32d23db3d0713b692a/scripts/exokit-install.sh#L3
- https://github.com/webmixedreality/exokit/blob/d5f59cb40ccc258e128c55542180e30ed1fce7c9/README.md#download-for-current-os