### PR TITLE
Add Discord webhook to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,3 +103,11 @@ notifications:
     - exokit:QzFMQYjtFRwrGm25iLOWxMTA#builds
     on_success: change
     on_failure: always
+after_success:
+  - wget https://raw.githubusercontent.com/webmixedreality/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - ./send.sh success $WEBHOOK_URL
+after_failure:
+  - wget https://raw.githubusercontent.com/webmixedreality/travis-ci-discord-webhook/master/send.sh
+  - chmod +x send.sh
+  - ./send.sh failure $WEBHOOK_URL


### PR DESCRIPTION
Uses script from https://github.com/webmixedreality/travis-ci-discord-webhook -- will need to add WEBHOOK_URL env variable in travis settings.